### PR TITLE
Use the multi-argument URI constructor instead of URI.create

### DIFF
--- a/http-server-undertow/src/main/java/io/micronaut/servlet/undertow/UndertowServer.java
+++ b/http-server-undertow/src/main/java/io/micronaut/servlet/undertow/UndertowServer.java
@@ -111,7 +111,11 @@ public class UndertowServer extends AbstractServletServer<Undertow> {
 
     @Override
     public URI getURI() {
-        return URI.create(getScheme() + "://" + getHost() + ":" + getPort());
+        try {
+            return new URI(getScheme(), null, getHost(), getPort(), null, null, null);
+        } catch(URISyntaxException e) {
+            throw new InternalServerException(e.getMessage(), e);
+        }
     }
 
     @Override

--- a/http-server-undertow/src/main/java/io/micronaut/servlet/undertow/UndertowServer.java
+++ b/http-server-undertow/src/main/java/io/micronaut/servlet/undertow/UndertowServer.java
@@ -113,7 +113,7 @@ public class UndertowServer extends AbstractServletServer<Undertow> {
     public URI getURI() {
         try {
             return new URI(getScheme(), null, getHost(), getPort(), null, null, null);
-        } catch(URISyntaxException e) {
+        } catch (URISyntaxException e) {
             throw new InternalServerException(e.getMessage(), e);
         }
     }


### PR DESCRIPTION
The present use of `URI.create` causes Micronaut to fail to start when `getHost` returns an IPv6 address.  Using the URI constructor instead will work for host names, IPv4 literals or IPv6 literals, wrapping the latter in square brackets (`[0:0:0:0:0:0:0:0]`) as required by the URI spec.

Closes #142