### PR TITLE
Change default host to 0.0.0.0.

### DIFF
--- a/servlet-engine/src/main/java/io/micronaut/servlet/engine/server/ServletServerFactory.java
+++ b/servlet-engine/src/main/java/io/micronaut/servlet/engine/server/ServletServerFactory.java
@@ -158,7 +158,7 @@ public abstract class ServletServerFactory extends SslBuilder<SSLContext> {
     protected String getConfiguredHost() {
         return serverConfiguration
                 .getHost()
-                .orElseGet(() -> Optional.ofNullable(System.getenv("HOST")).orElse("localhost"));
+                .orElseGet(() -> Optional.ofNullable(System.getenv("HOST")).orElse("0.0.0.0"));
     }
 
     /**


### PR DESCRIPTION
This makes sure that Jetty listens on all interfaces - otherwise it will not work in a Docker Container by default.

If you create a new empty Micronaut Project, add a simple REST Controller, and switch to the server runtime "Jetty", then the endpoint will not be available when deployed on Docker. Instead you get "Empty Reply from server".
The reason is that by default Jetty listens on "localhost", see https://github.com/micronaut-projects/micronaut-servlet/blob/master/servlet-engine/src/main/java/io/micronaut/servlet/engine/server/ServletServerFactory.java#L158

However, the server runtime Netty works by default. I can workaround the issue by setting "micronaut.server.host=0.0.0.0". 

See also https://github.com/tobiasschaefer/jetty-in-docker to reproduce the behaviour.

Note: this makes the behaviour identical to Netty.

I know that this makes Jetty accessible on all interfaces by default and is a change in respect to security.

This PR is basically up to discussion. I created it based on a short discussion on Gitter with @jameskleeh yesterday.