### PR TITLE
Fix of tomcat throwing exception on Windows

### DIFF
--- a/http-server-tomcat/src/main/java/io/micronaut/servlet/tomcat/TomcatFactory.java
+++ b/http-server-tomcat/src/main/java/io/micronaut/servlet/tomcat/TomcatFactory.java
@@ -90,6 +90,14 @@ public class TomcatFactory extends ServletServerFactory {
         tomcat.setConnector(connector);
         final String cp = contextPath != null && !contextPath.equals("/") ? contextPath : "";
         final Context context = tomcat.addContext(cp, "/");
+
+        // add required folder
+        File docBaseFile = new File(context.getDocBase());
+        if (!docBaseFile.isAbsolute()) {
+            docBaseFile = new File(((org.apache.catalina.Host) context.getParent()).getAppBaseFile(), docBaseFile.getPath());
+        }
+        docBaseFile.mkdirs();
+
         final Wrapper servlet = Tomcat.addServlet(
                 context,
                 configuration.getName(),


### PR DESCRIPTION
Fix of this issue: [https://github.com/micronaut-projects/micronaut-servlet/issues/191](https://github.com/micronaut-projects/micronaut-servlet/issues/191)
The fix adds a 'webapps' folder inside 'tomcat:port', which should be there.