### PR TITLE
Use default getUserPrincipal implementation before delegating

### DIFF
--- a/http-server-jetty/build.gradle
+++ b/http-server-jetty/build.gradle
@@ -13,4 +13,6 @@ dependencies {
     testImplementation "io.micronaut:micronaut-http-client"
     testImplementation "io.micronaut.test:micronaut-test-spock:$micronautTestVersion"
     testImplementation("org.codehaus.groovy:groovy-json")
+
+    testImplementation "io.micronaut.security:micronaut-security"
 }

--- a/http-server-jetty/src/test/groovy/io/micronaut/servlet/jetty/JettyPrincipalBindingSpec.groovy
+++ b/http-server-jetty/src/test/groovy/io/micronaut/servlet/jetty/JettyPrincipalBindingSpec.groovy
@@ -1,0 +1,81 @@
+package io.micronaut.servlet.jetty
+
+import io.micronaut.context.annotation.Property
+import io.micronaut.context.annotation.Requires
+import io.micronaut.core.annotation.Nullable
+import io.micronaut.http.HttpRequest
+import io.micronaut.http.HttpResponse
+import io.micronaut.http.HttpStatus
+import io.micronaut.http.MediaType
+import io.micronaut.http.annotation.Controller
+import io.micronaut.http.annotation.Get
+import io.micronaut.http.annotation.Produces
+import io.micronaut.http.client.RxHttpClient
+import io.micronaut.http.client.annotation.Client
+import io.micronaut.security.annotation.Secured
+import io.micronaut.security.authentication.AuthenticationException
+import io.micronaut.security.authentication.AuthenticationFailed
+import io.micronaut.security.authentication.AuthenticationProvider
+import io.micronaut.security.authentication.AuthenticationRequest
+import io.micronaut.security.authentication.AuthenticationResponse
+import io.micronaut.security.authentication.UserDetails
+import io.micronaut.security.rules.SecurityRule
+import io.micronaut.test.extensions.spock.annotation.MicronautTest
+import io.reactivex.BackpressureStrategy
+import io.reactivex.Flowable
+import org.reactivestreams.Publisher
+import spock.lang.Specification
+
+import javax.inject.Inject
+import javax.inject.Singleton
+import java.security.Principal
+
+@MicronautTest
+@Property(name = 'micronaut.security.enabled', value = 'true')
+@Property(name = 'spec.name', value = 'JettyPrincipalBindingSpec')
+class JettyPrincipalBindingSpec extends Specification {
+
+    @Inject
+    @Client('/')
+    RxHttpClient client;
+
+    void 'test that Principal binds in a secured method'() {
+        when:
+        def request = HttpRequest.GET('/principal').basicAuth('sherlock', 'password')
+        def response = client.toBlocking().exchange(request, String)
+
+        then:
+        response.status == HttpStatus.OK
+        response.body() == 'sherlock'
+    }
+
+    @Requires(property = 'spec.name', value = 'JettyPrincipalBindingSpec')
+    @Controller('/principal')
+    static class DemoController {
+
+        @Produces(MediaType.TEXT_PLAIN)
+        @Secured(SecurityRule.IS_AUTHENTICATED)
+        @Get
+        String index(Principal principal) {
+            principal.name
+        }
+    }
+
+    @Requires(property = 'spec.name', value = 'JettyPrincipalBindingSpec')
+    @Singleton
+    static class AuthenticationProviderUserPassword implements AuthenticationProvider {
+        @Override
+        Publisher<AuthenticationResponse> authenticate(HttpRequest<?> httpRequest, AuthenticationRequest<?, ?> authenticationRequest) {
+            Flowable.create({ emitter ->
+                String identity = authenticationRequest.identity
+                if (identity == 'sherlock' && authenticationRequest.secret == 'password') {
+                    emitter.onNext(new UserDetails(identity, []))
+                    emitter.onComplete()
+                } else {
+                    emitter.onError(new AuthenticationException(new AuthenticationFailed()))
+                }
+
+            }, BackpressureStrategy.ERROR) as Publisher<AuthenticationResponse>
+        }
+    }
+}

--- a/http-server-jetty/src/test/groovy/io/micronaut/servlet/jetty/JettyPrincipalBindingSpec.groovy
+++ b/http-server-jetty/src/test/groovy/io/micronaut/servlet/jetty/JettyPrincipalBindingSpec.groovy
@@ -2,9 +2,7 @@ package io.micronaut.servlet.jetty
 
 import io.micronaut.context.annotation.Property
 import io.micronaut.context.annotation.Requires
-import io.micronaut.core.annotation.Nullable
 import io.micronaut.http.HttpRequest
-import io.micronaut.http.HttpResponse
 import io.micronaut.http.HttpStatus
 import io.micronaut.http.MediaType
 import io.micronaut.http.annotation.Controller

--- a/http-server-jetty/src/test/groovy/io/micronaut/servlet/jetty/JettyPrincipalBindingSpec.groovy
+++ b/http-server-jetty/src/test/groovy/io/micronaut/servlet/jetty/JettyPrincipalBindingSpec.groovy
@@ -22,12 +22,14 @@ import io.micronaut.test.extensions.spock.annotation.MicronautTest
 import io.reactivex.BackpressureStrategy
 import io.reactivex.Flowable
 import org.reactivestreams.Publisher
+import spock.lang.Issue
 import spock.lang.Specification
 
 import javax.inject.Inject
 import javax.inject.Singleton
 import java.security.Principal
 
+@Issue('https://github.com/micronaut-projects/micronaut-core/issues/5395')
 @MicronautTest
 @Property(name = 'micronaut.security.enabled', value = 'true')
 @Property(name = 'spec.name', value = 'JettyPrincipalBindingSpec')

--- a/http-server-jetty/src/test/resources/application-test.yaml
+++ b/http-server-jetty/src/test/resources/application-test.yaml
@@ -1,0 +1,6 @@
+# Globally Disable micronaut-security for test environment (so most tests can ignore security concerns).
+# Individual tests that require @Secured, etc. should annotate the test with:
+#     @Property(name = 'micronaut.security.enabled', value = 'true')
+micronaut:
+  security:
+    enabled: false

--- a/http-server-tomcat/build.gradle
+++ b/http-server-tomcat/build.gradle
@@ -12,6 +12,8 @@ dependencies {
     testImplementation "io.micronaut:micronaut-inject-groovy"
     testImplementation "io.micronaut:micronaut-http-client"
     testImplementation "io.micronaut.test:micronaut-test-spock:$micronautTestVersion"
+
+    testImplementation "io.micronaut.security:micronaut-security"
 }
 
 micronautBuild {

--- a/http-server-tomcat/src/test/groovy/io/micronaut/servlet/tomcat/TomcatPrincipalBindingSpec.groovy
+++ b/http-server-tomcat/src/test/groovy/io/micronaut/servlet/tomcat/TomcatPrincipalBindingSpec.groovy
@@ -2,9 +2,7 @@ package io.micronaut.servlet.tomcat
 
 import io.micronaut.context.annotation.Property
 import io.micronaut.context.annotation.Requires
-import io.micronaut.core.annotation.Nullable
 import io.micronaut.http.HttpRequest
-import io.micronaut.http.HttpResponse
 import io.micronaut.http.HttpStatus
 import io.micronaut.http.MediaType
 import io.micronaut.http.annotation.Controller

--- a/http-server-tomcat/src/test/groovy/io/micronaut/servlet/tomcat/TomcatPrincipalBindingSpec.groovy
+++ b/http-server-tomcat/src/test/groovy/io/micronaut/servlet/tomcat/TomcatPrincipalBindingSpec.groovy
@@ -1,0 +1,81 @@
+package io.micronaut.servlet.tomcat
+
+import io.micronaut.context.annotation.Property
+import io.micronaut.context.annotation.Requires
+import io.micronaut.core.annotation.Nullable
+import io.micronaut.http.HttpRequest
+import io.micronaut.http.HttpResponse
+import io.micronaut.http.HttpStatus
+import io.micronaut.http.MediaType
+import io.micronaut.http.annotation.Controller
+import io.micronaut.http.annotation.Get
+import io.micronaut.http.annotation.Produces
+import io.micronaut.http.client.RxHttpClient
+import io.micronaut.http.client.annotation.Client
+import io.micronaut.security.annotation.Secured
+import io.micronaut.security.authentication.AuthenticationException
+import io.micronaut.security.authentication.AuthenticationFailed
+import io.micronaut.security.authentication.AuthenticationProvider
+import io.micronaut.security.authentication.AuthenticationRequest
+import io.micronaut.security.authentication.AuthenticationResponse
+import io.micronaut.security.authentication.UserDetails
+import io.micronaut.security.rules.SecurityRule
+import io.micronaut.test.extensions.spock.annotation.MicronautTest
+import io.reactivex.BackpressureStrategy
+import io.reactivex.Flowable
+import org.reactivestreams.Publisher
+import spock.lang.Specification
+
+import javax.inject.Inject
+import javax.inject.Singleton
+import java.security.Principal
+
+@MicronautTest
+@Property(name = 'micronaut.security.enabled', value = 'true')
+@Property(name = 'spec.name', value = 'TomcatPrincipalBindingSpec')
+class TomcatPrincipalBindingSpec extends Specification {
+
+    @Inject
+    @Client('/')
+    RxHttpClient client;
+
+    void 'test that Principal binds in a secured method'() {
+        when:
+        def request = HttpRequest.GET('/principal').basicAuth('sherlock', 'password')
+        def response = client.toBlocking().exchange(request, String)
+
+        then:
+        response.status == HttpStatus.OK
+        response.body() == 'sherlock'
+    }
+
+    @Requires(property = 'spec.name', value = 'TomcatPrincipalBindingSpec')
+    @Controller('/principal')
+    static class DemoController {
+
+        @Produces(MediaType.TEXT_PLAIN)
+        @Secured(SecurityRule.IS_AUTHENTICATED)
+        @Get
+        String index(Principal principal) {
+            principal.name
+        }
+    }
+
+    @Requires(property = 'spec.name', value = 'TomcatPrincipalBindingSpec')
+    @Singleton
+    static class AuthenticationProviderUserPassword implements AuthenticationProvider {
+        @Override
+        Publisher<AuthenticationResponse> authenticate(HttpRequest<?> httpRequest, AuthenticationRequest<?, ?> authenticationRequest) {
+            Flowable.create({ emitter ->
+                String identity = authenticationRequest.identity
+                if (identity == 'sherlock' && authenticationRequest.secret == 'password') {
+                    emitter.onNext(new UserDetails(identity, []))
+                    emitter.onComplete()
+                } else {
+                    emitter.onError(new AuthenticationException(new AuthenticationFailed()))
+                }
+
+            }, BackpressureStrategy.ERROR) as Publisher<AuthenticationResponse>
+        }
+    }
+}

--- a/http-server-tomcat/src/test/groovy/io/micronaut/servlet/tomcat/TomcatPrincipalBindingSpec.groovy
+++ b/http-server-tomcat/src/test/groovy/io/micronaut/servlet/tomcat/TomcatPrincipalBindingSpec.groovy
@@ -22,12 +22,14 @@ import io.micronaut.test.extensions.spock.annotation.MicronautTest
 import io.reactivex.BackpressureStrategy
 import io.reactivex.Flowable
 import org.reactivestreams.Publisher
+import spock.lang.Issue
 import spock.lang.Specification
 
 import javax.inject.Inject
 import javax.inject.Singleton
 import java.security.Principal
 
+@Issue('https://github.com/micronaut-projects/micronaut-core/issues/5395')
 @MicronautTest
 @Property(name = 'micronaut.security.enabled', value = 'true')
 @Property(name = 'spec.name', value = 'TomcatPrincipalBindingSpec')

--- a/http-server-tomcat/src/test/resources/application-test.yaml
+++ b/http-server-tomcat/src/test/resources/application-test.yaml
@@ -1,0 +1,6 @@
+# Globally Disable micronaut-security for test environment (so most tests can ignore security concerns).
+# Individual tests that require @Secured, etc. should annotate the test with:
+#     @Property(name = 'micronaut.security.enabled', value = 'true')
+micronaut:
+  security:
+    enabled: false

--- a/http-server-undertow/build.gradle
+++ b/http-server-undertow/build.gradle
@@ -10,4 +10,6 @@ dependencies {
     testImplementation "io.micronaut:micronaut-inject-groovy"
     testImplementation "io.micronaut:micronaut-http-client"
     testImplementation "io.micronaut.test:micronaut-test-spock:$micronautTestVersion"
+
+    testImplementation "io.micronaut.security:micronaut-security"
 }

--- a/http-server-undertow/src/test/groovy/io/micronaut/servlet/undertow/UndertowPrincipalBindingSpec.groovy
+++ b/http-server-undertow/src/test/groovy/io/micronaut/servlet/undertow/UndertowPrincipalBindingSpec.groovy
@@ -1,0 +1,82 @@
+package io.micronaut.servlet.undertow
+
+
+import io.micronaut.context.annotation.Property
+import io.micronaut.context.annotation.Requires
+import io.micronaut.core.annotation.Nullable
+import io.micronaut.http.HttpRequest
+import io.micronaut.http.HttpResponse
+import io.micronaut.http.HttpStatus
+import io.micronaut.http.MediaType
+import io.micronaut.http.annotation.Controller
+import io.micronaut.http.annotation.Get
+import io.micronaut.http.annotation.Produces
+import io.micronaut.http.client.RxHttpClient
+import io.micronaut.http.client.annotation.Client
+import io.micronaut.security.annotation.Secured
+import io.micronaut.security.authentication.AuthenticationException
+import io.micronaut.security.authentication.AuthenticationFailed
+import io.micronaut.security.authentication.AuthenticationProvider
+import io.micronaut.security.authentication.AuthenticationRequest
+import io.micronaut.security.authentication.AuthenticationResponse
+import io.micronaut.security.authentication.UserDetails
+import io.micronaut.security.rules.SecurityRule
+import io.micronaut.test.extensions.spock.annotation.MicronautTest
+import io.reactivex.BackpressureStrategy
+import io.reactivex.Flowable
+import org.reactivestreams.Publisher
+import spock.lang.Specification
+
+import javax.inject.Inject
+import javax.inject.Singleton
+import java.security.Principal
+
+@MicronautTest
+@Property(name = 'micronaut.security.enabled', value = 'true')
+@Property(name = 'spec.name', value = 'UndertowPrincipalBindingSpec')
+class UndertowPrincipalBindingSpec extends Specification {
+
+    @Inject
+    @Client('/')
+    RxHttpClient client;
+
+    void 'test that Principal binds in a secured method'() {
+        when:
+        def request = HttpRequest.GET('/principal').basicAuth('sherlock', 'password')
+        def response = client.toBlocking().exchange(request, String)
+
+        then:
+        response.status == HttpStatus.OK
+        response.body() == 'sherlock'
+    }
+
+    @Requires(property = 'spec.name', value = 'UndertowPrincipalBindingSpec')
+    @Controller('/principal')
+    static class DemoController {
+
+        @Produces(MediaType.TEXT_PLAIN)
+        @Secured(SecurityRule.IS_AUTHENTICATED)
+        @Get
+        String index(Principal principal) {
+            principal.name
+        }
+    }
+
+    @Requires(property = 'spec.name', value = 'UndertowPrincipalBindingSpec')
+    @Singleton
+    static class AuthenticationProviderUserPassword implements AuthenticationProvider {
+        @Override
+        Publisher<AuthenticationResponse> authenticate(HttpRequest<?> httpRequest, AuthenticationRequest<?, ?> authenticationRequest) {
+            Flowable.create({ emitter ->
+                String identity = authenticationRequest.identity
+                if (identity == 'sherlock' && authenticationRequest.secret == 'password') {
+                    emitter.onNext(new UserDetails(identity, []))
+                    emitter.onComplete()
+                } else {
+                    emitter.onError(new AuthenticationException(new AuthenticationFailed()))
+                }
+
+            }, BackpressureStrategy.ERROR) as Publisher<AuthenticationResponse>
+        }
+    }
+}

--- a/http-server-undertow/src/test/groovy/io/micronaut/servlet/undertow/UndertowPrincipalBindingSpec.groovy
+++ b/http-server-undertow/src/test/groovy/io/micronaut/servlet/undertow/UndertowPrincipalBindingSpec.groovy
@@ -22,12 +22,14 @@ import io.micronaut.test.extensions.spock.annotation.MicronautTest
 import io.reactivex.BackpressureStrategy
 import io.reactivex.Flowable
 import org.reactivestreams.Publisher
+import spock.lang.Issue
 import spock.lang.Specification
 
 import javax.inject.Inject
 import javax.inject.Singleton
 import java.security.Principal
 
+@Issue('https://github.com/micronaut-projects/micronaut-core/issues/5395')
 @MicronautTest
 @Property(name = 'micronaut.security.enabled', value = 'true')
 @Property(name = 'spec.name', value = 'UndertowPrincipalBindingSpec')

--- a/http-server-undertow/src/test/groovy/io/micronaut/servlet/undertow/UndertowPrincipalBindingSpec.groovy
+++ b/http-server-undertow/src/test/groovy/io/micronaut/servlet/undertow/UndertowPrincipalBindingSpec.groovy
@@ -1,11 +1,8 @@
 package io.micronaut.servlet.undertow
 
-
 import io.micronaut.context.annotation.Property
 import io.micronaut.context.annotation.Requires
-import io.micronaut.core.annotation.Nullable
 import io.micronaut.http.HttpRequest
-import io.micronaut.http.HttpResponse
 import io.micronaut.http.HttpStatus
 import io.micronaut.http.MediaType
 import io.micronaut.http.annotation.Controller

--- a/http-server-undertow/src/test/resources/application-test.yaml
+++ b/http-server-undertow/src/test/resources/application-test.yaml
@@ -1,0 +1,6 @@
+# Globally Disable micronaut-security for test environment (so most tests can ignore security concerns).
+# Individual tests that require @Secured, etc. should annotate the test with:
+#     @Property(name = 'micronaut.security.enabled', value = 'true')
+micronaut:
+  security:
+    enabled: false

--- a/servlet-engine/src/main/java/io/micronaut/servlet/engine/DefaultServletHttpRequest.java
+++ b/servlet-engine/src/main/java/io/micronaut/servlet/engine/DefaultServletHttpRequest.java
@@ -206,12 +206,6 @@ public class DefaultServletHttpRequest<B> implements
         return Optional.empty();
     }
 
-    @NonNull
-    @Override
-    public Optional<Principal> getUserPrincipal() {
-        return Optional.ofNullable(delegate.getUserPrincipal());
-    }
-
     @Override
     public boolean isSecure() {
         return delegate.isSecure();

--- a/servlet-engine/src/main/java/io/micronaut/servlet/engine/DefaultServletHttpRequest.java
+++ b/servlet-engine/src/main/java/io/micronaut/servlet/engine/DefaultServletHttpRequest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2020 original authors
+ * Copyright 2017-2021 original authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -204,6 +204,15 @@ public class DefaultServletHttpRequest<B> implements
             }
         }
         return Optional.empty();
+    }
+
+    @NonNull
+    @Override
+    public Optional<Principal> getUserPrincipal() {
+        return Optional.ofNullable(
+                ServletHttpRequest.super.getUserPrincipal()
+                        .orElse(delegate.getUserPrincipal())
+        );
     }
 
     @Override


### PR DESCRIPTION
Fixes https://github.com/micronaut-projects/micronaut-core/issues/5395

`DefaultServletHttpRequest` would delegate calls to `getUserPrincipal` to the servlet request class, which would then end up in the internals of Jetty/Tomcat/Undertow, rather than using the micronaut mechanisms.  Once removed, proper handling of `getUserPrincipal` is done as a default implementation in the `HttpRequest` interface.

