### PR TITLE
Change default Content-Type for String methods to application/json

### DIFF
--- a/http-server-jetty/src/test/groovy/io/micronaut/servlet/jetty/JettyContentTypeSpec.groovy
+++ b/http-server-jetty/src/test/groovy/io/micronaut/servlet/jetty/JettyContentTypeSpec.groovy
@@ -1,0 +1,142 @@
+package io.micronaut.servlet.jetty
+
+import io.micronaut.context.annotation.Property
+import io.micronaut.context.annotation.Requires
+import io.micronaut.http.HttpRequest
+import io.micronaut.http.HttpResponse
+import io.micronaut.http.MediaType
+import io.micronaut.http.annotation.Body
+import io.micronaut.http.annotation.Controller
+import io.micronaut.http.annotation.Post
+import io.micronaut.http.annotation.Produces
+import io.micronaut.http.client.RxHttpClient
+import io.micronaut.http.client.annotation.Client
+import io.micronaut.test.extensions.spock.annotation.MicronautTest
+import io.reactivex.Single
+import spock.lang.Specification
+
+import javax.inject.Inject
+
+@MicronautTest
+@Property(name = 'spec.name', value = 'JettyContentTypeSpec')
+class JettyContentTypeSpec extends Specification {
+
+    @Inject
+    @Client('/contentType')
+    RxHttpClient client
+
+    void 'test that method returning String without @Produces will have JSON response content-type'() {
+        when:
+        def response = client.exchange(
+                HttpRequest.POST('/default/simple', 'foobar'), String
+        ).blockingFirst()
+
+        then:
+        response.contentType.isPresent()
+        response.contentType.get() == MediaType.APPLICATION_JSON_TYPE
+        response.body() == 'Body: foobar'
+    }
+    
+    void 'test that method returning HttpResponse without @Produces will have JSON response content-type'() {
+        when:
+        def response = client.exchange(
+                HttpRequest.POST('/default/response', 'foobar'), String
+        ).blockingFirst()
+
+        then:
+        response.contentType.isPresent()
+        response.contentType.get() == MediaType.APPLICATION_JSON_TYPE
+        response.body() == 'Body: foobar'
+    }
+    
+    void 'test that method returning Single without @Produces will have JSON response content-type'() {
+        when:
+        def response = client.exchange(
+                HttpRequest.POST('/default/reactive', 'foobar'), String
+        ).blockingFirst()
+
+        then:
+        response.contentType.isPresent()
+        response.contentType.get() == MediaType.APPLICATION_JSON_TYPE
+        response.body() == 'Body: foobar'
+    }
+
+    void 'test that method returning String with @Produces TEXT_PLAIN will have text response content-type'() {
+        when:
+        def response = client.exchange(
+                HttpRequest.POST('/plainText/simple', 'foobar'), String
+        ).blockingFirst()
+
+        then:
+        response.contentType.isPresent()
+        response.contentType.get() == MediaType.TEXT_PLAIN_TYPE
+        response.body() == 'Body: foobar'
+    }
+
+    void 'test that method returning HttpResponse with @Produces TEXT_PLAIN will have text response content-type'() {
+        when:
+        def response = client.exchange(
+                HttpRequest.POST('/plainText/response', 'foobar'), String
+        ).blockingFirst()
+
+        then:
+        response.contentType.isPresent()
+        response.contentType.get() == MediaType.TEXT_PLAIN_TYPE
+        response.body() == 'Body: foobar'
+    }
+
+    void 'test that method returning Single with @Produces TEXT_PLAIN will have text response content-type'() {
+        when:
+        def response = client.exchange(
+                HttpRequest.POST('/plainText/reactive', 'foobar'), String
+        ).blockingFirst()
+
+        then:
+        response.contentType.isPresent()
+        response.contentType.get() == MediaType.TEXT_PLAIN_TYPE
+        response.body() == 'Body: foobar'
+    }
+
+    @Requires(property = 'spec.name', value = 'JettyContentTypeSpec')
+    @Controller('/contentType/default')
+    static class DefaultContentTypeController extends ContentTypeControllerBase {
+        @Post('/simple')
+        String simple(@Body String text) {
+            result(text)
+        }
+        @Post('/response')
+        HttpResponse<String> response(@Body String text) {
+            HttpResponse<String>.ok(result(text))
+        }
+        @Post('/reactive')
+        Single<String> reactive(@Body String text) {
+            Single<String>.just(result(text))
+        }
+    }
+
+    @Requires(property = 'spec.name', value = 'JettyContentTypeSpec')
+    @Controller('/contentType/plainText')
+    @Produces(MediaType.TEXT_PLAIN)
+    static class PlainTextContentTypeController extends ContentTypeControllerBase {
+        @Post('/simple')
+        String simple(@Body String text) {
+            result(text)
+        }
+        @Post('/response')
+        HttpResponse<String> response(@Body String text) {
+            HttpResponse<String>.ok(result(text))
+        }
+        @Post('/reactive')
+        Single<String> reactive(@Body String text) {
+            Single<String>.just(result(text))
+        }
+    }
+
+    private static class ContentTypeControllerBase {
+        @SuppressWarnings('GrMethodMayBeStatic')
+        String result(String text) {
+            "Body: $text"
+        }
+    }
+
+}

--- a/http-server-jetty/src/test/groovy/io/micronaut/servlet/jetty/JettyContentTypeSpec.groovy
+++ b/http-server-jetty/src/test/groovy/io/micronaut/servlet/jetty/JettyContentTypeSpec.groovy
@@ -13,12 +13,14 @@ import io.micronaut.http.client.RxHttpClient
 import io.micronaut.http.client.annotation.Client
 import io.micronaut.test.extensions.spock.annotation.MicronautTest
 import io.reactivex.Single
+import spock.lang.Issue
 import spock.lang.Specification
 
 import javax.inject.Inject
 
 @MicronautTest
 @Property(name = 'spec.name', value = 'JettyContentTypeSpec')
+@Issue('https://github.com/micronaut-projects/micronaut-servlet/issues/206')
 class JettyContentTypeSpec extends Specification {
 
     @Inject

--- a/http-server-jetty/src/test/java/io/micronaut/servlet/jetty/ParametersController.java
+++ b/http-server-jetty/src/test/java/io/micronaut/servlet/jetty/ParametersController.java
@@ -14,26 +14,22 @@ import java.io.*;
 @Controller("/parameters")
 public class ParametersController {
 
-    @Get("/uri/{name}")
-    @Produces(MediaType.TEXT_PLAIN)
+    @Get(value = "/uri/{name}", produces = MediaType.TEXT_PLAIN)
     String uriParam(String name) {
         return "Hello " + name;
     }
 
-    @Get("/query")
-    @Produces(MediaType.TEXT_PLAIN)
+    @Get(value = "/query", produces = MediaType.TEXT_PLAIN)
     String queryValue(@QueryValue("q") String name) {
         return "Hello " + name;
     }
 
-    @Get("/allParams")
-    @Produces(MediaType.TEXT_PLAIN)
+    @Get(value = "/allParams", produces = MediaType.TEXT_PLAIN)
     String allParams(HttpParameters parameters) {
         return "Hello " + parameters.get("name") + " " + parameters.get("age", int.class).orElse(null);
     }
 
-    @Get("/header")
-    @Produces(MediaType.TEXT_PLAIN)
+    @Get(value = "/header", produces = MediaType.TEXT_PLAIN)
     String headerValue(@Header(HttpHeaders.CONTENT_TYPE) String contentType) {
         return "Hello " + contentType;
     }
@@ -54,30 +50,27 @@ public class ParametersController {
         }
     }
 
-    @Post("/stringBody")
-    @Consumes("text/plain")
-    @Produces(MediaType.TEXT_PLAIN)
+    @Post(value = "/stringBody", processes = MediaType.TEXT_PLAIN)
     String stringBody(@Body String body) {
         return "Hello " + body;
     }
 
-    @Post("/bytesBody")
-    @Consumes("text/plain")
+    @Post(value = "/bytesBody", processes = MediaType.TEXT_PLAIN)
     String bytesBody(@Body byte[] body) {
         return "Hello " + new String(body);
     }
 
-    @Post(value = "/jsonBody", processes = "application/json")
+    @Post(value = "/jsonBody", processes = MediaType.APPLICATION_JSON)
     Person jsonBody(@Body Person body) {
         return body;
     }
 
-    @Post(value = "/jsonBodySpread", processes = "application/json")
+    @Post(value = "/jsonBodySpread", processes = MediaType.APPLICATION_JSON)
     Person jsonBody(String name, int age) {
         return new Person(name, age);
     }
 
-    @Post(value = "/fullRequest", processes = "application/json")
+    @Post(value = "/fullRequest", processes = MediaType.APPLICATION_JSON)
     io.micronaut.http.HttpResponse<Person> fullReq(io.micronaut.http.HttpRequest<Person> request) {
         final Person person = request.getBody().orElseThrow(() -> new RuntimeException("No body"));
         final MutableHttpResponse<Person> response = io.micronaut.http.HttpResponse.ok(person);
@@ -85,15 +78,14 @@ public class ParametersController {
         return response;
     }
 
-    @Post(value = "/writable", processes = "text/plain")
+    @Post(value = "/writable", processes = MediaType.TEXT_PLAIN)
     @Header(name = "Foo", value = "Bar")
     @Status(HttpStatus.CREATED)
     Writable fullReq(@Body String text) {
         return out -> out.append("Hello ").append(text);
     }
 
-
-    @Post(value = "/multipart", consumes = MediaType.MULTIPART_FORM_DATA, produces = "text/plain")
+    @Post(value = "/multipart", consumes = MediaType.MULTIPART_FORM_DATA, produces = MediaType.TEXT_PLAIN)
     String multipart(
             String foo,
             @Part("one") Person person,

--- a/http-server-jetty/src/test/java/io/micronaut/servlet/jetty/ParametersController.java
+++ b/http-server-jetty/src/test/java/io/micronaut/servlet/jetty/ParametersController.java
@@ -15,21 +15,25 @@ import java.io.*;
 public class ParametersController {
 
     @Get("/uri/{name}")
+    @Produces(MediaType.TEXT_PLAIN)
     String uriParam(String name) {
         return "Hello " + name;
     }
 
     @Get("/query")
+    @Produces(MediaType.TEXT_PLAIN)
     String queryValue(@QueryValue("q") String name) {
         return "Hello " + name;
     }
 
     @Get("/allParams")
+    @Produces(MediaType.TEXT_PLAIN)
     String allParams(HttpParameters parameters) {
         return "Hello " + parameters.get("name") + " " + parameters.get("age", int.class).orElse(null);
     }
 
     @Get("/header")
+    @Produces(MediaType.TEXT_PLAIN)
     String headerValue(@Header(HttpHeaders.CONTENT_TYPE) String contentType) {
         return "Hello " + contentType;
     }
@@ -52,6 +56,7 @@ public class ParametersController {
 
     @Post("/stringBody")
     @Consumes("text/plain")
+    @Produces(MediaType.TEXT_PLAIN)
     String stringBody(@Body String body) {
         return "Hello " + body;
     }

--- a/http-server-tomcat/src/test/groovy/io/micronaut/servlet/tomcat/TomcatContentTypeSpec.groovy
+++ b/http-server-tomcat/src/test/groovy/io/micronaut/servlet/tomcat/TomcatContentTypeSpec.groovy
@@ -21,6 +21,7 @@ import javax.inject.Inject
 
 @MicronautTest
 @Property(name = 'spec.name', value = 'TomcatContentTypeSpec')
+@Issue('https://github.com/micronaut-projects/micronaut-servlet/issues/206')
 class TomcatContentTypeSpec extends Specification {
 
     @Inject
@@ -37,7 +38,6 @@ class TomcatContentTypeSpec extends Specification {
         response.contentType.get() == MediaType.APPLICATION_JSON_TYPE
     }
 
-    @Issue('https://github.com/micronaut-projects/micronaut-servlet/issues/206')
     void 'test that method returning String without @Produces will have JSON response content-type'() {
         when:
         def response = client.exchange(
@@ -50,7 +50,6 @@ class TomcatContentTypeSpec extends Specification {
         response.body() == 'Body: foobar'
     }
 
-    @Issue('https://github.com/micronaut-projects/micronaut-servlet/issues/206')
     void 'test that method returning HttpResponse without @Produces will have JSON response content-type'() {
         when:
         def response = client.exchange(
@@ -63,7 +62,6 @@ class TomcatContentTypeSpec extends Specification {
         response.body() == 'Body: foobar'
     }
 
-    @Issue('https://github.com/micronaut-projects/micronaut-servlet/issues/206')
     void 'test that method returning Single without @Produces will have JSON response content-type'() {
         when:
         def response = client.exchange(
@@ -76,7 +74,6 @@ class TomcatContentTypeSpec extends Specification {
         response.body() == 'Body: foobar'
     }
 
-    @Issue('https://github.com/micronaut-projects/micronaut-servlet/issues/206')
     void 'test that method returning String with @Produces TEXT_PLAIN will have text response content-type'() {
         when:
         def response = client.exchange(
@@ -89,7 +86,6 @@ class TomcatContentTypeSpec extends Specification {
         response.body() == 'Body: foobar'
     }
 
-    @Issue('https://github.com/micronaut-projects/micronaut-servlet/issues/206')
     void 'test that method returning HttpResponse with @Produces TEXT_PLAIN will have text response content-type'() {
         when:
         def response = client.exchange(
@@ -102,7 +98,6 @@ class TomcatContentTypeSpec extends Specification {
         response.body() == 'Body: foobar'
     }
 
-    @Issue('https://github.com/micronaut-projects/micronaut-servlet/issues/206')
     void 'test that method returning Single with @Produces TEXT_PLAIN will have text response content-type'() {
         when:
         def response = client.exchange(

--- a/http-server-tomcat/src/test/groovy/io/micronaut/servlet/tomcat/TomcatContentTypeSpec.groovy
+++ b/http-server-tomcat/src/test/groovy/io/micronaut/servlet/tomcat/TomcatContentTypeSpec.groovy
@@ -1,0 +1,142 @@
+package io.micronaut.servlet.tomcat
+
+import io.micronaut.context.annotation.Property
+import io.micronaut.context.annotation.Requires
+import io.micronaut.http.HttpRequest
+import io.micronaut.http.HttpResponse
+import io.micronaut.http.MediaType
+import io.micronaut.http.annotation.Body
+import io.micronaut.http.annotation.Controller
+import io.micronaut.http.annotation.Post
+import io.micronaut.http.annotation.Produces
+import io.micronaut.http.client.RxHttpClient
+import io.micronaut.http.client.annotation.Client
+import io.micronaut.test.extensions.spock.annotation.MicronautTest
+import io.reactivex.Single
+import spock.lang.Specification
+
+import javax.inject.Inject
+
+@MicronautTest
+@Property(name = 'spec.name', value = 'TomcatContentTypeSpec')
+class TomcatContentTypeSpec extends Specification {
+
+    @Inject
+    @Client('/contentType')
+    RxHttpClient client
+
+    void 'test that method returning String without @Produces will have JSON response content-type'() {
+        when:
+        def response = client.exchange(
+                HttpRequest.POST('/default/simple', 'foobar'), String
+        ).blockingFirst()
+
+        then:
+        response.contentType.isPresent()
+        response.contentType.get() == MediaType.APPLICATION_JSON_TYPE
+        response.body() == 'Body: foobar'
+    }
+
+    void 'test that method returning HttpResponse without @Produces will have JSON response content-type'() {
+        when:
+        def response = client.exchange(
+                HttpRequest.POST('/default/response', 'foobar'), String
+        ).blockingFirst()
+
+        then:
+        response.contentType.isPresent()
+        response.contentType.get() == MediaType.APPLICATION_JSON_TYPE
+        response.body() == 'Body: foobar'
+    }
+
+    void 'test that method returning Single without @Produces will have JSON response content-type'() {
+        when:
+        def response = client.exchange(
+                HttpRequest.POST('/default/reactive', 'foobar'), String
+        ).blockingFirst()
+
+        then:
+        response.contentType.isPresent()
+        response.contentType.get() == MediaType.APPLICATION_JSON_TYPE
+        response.body() == 'Body: foobar'
+    }
+
+    void 'test that method returning String with @Produces TEXT_PLAIN will have text response content-type'() {
+        when:
+        def response = client.exchange(
+                HttpRequest.POST('/plainText/simple', 'foobar'), String
+        ).blockingFirst()
+
+        then:
+        response.contentType.isPresent()
+        response.contentType.get() == MediaType.TEXT_PLAIN_TYPE
+        response.body() == 'Body: foobar'
+    }
+
+    void 'test that method returning HttpResponse with @Produces TEXT_PLAIN will have text response content-type'() {
+        when:
+        def response = client.exchange(
+                HttpRequest.POST('/plainText/response', 'foobar'), String
+        ).blockingFirst()
+
+        then:
+        response.contentType.isPresent()
+        response.contentType.get() == MediaType.TEXT_PLAIN_TYPE
+        response.body() == 'Body: foobar'
+    }
+
+    void 'test that method returning Single with @Produces TEXT_PLAIN will have text response content-type'() {
+        when:
+        def response = client.exchange(
+                HttpRequest.POST('/plainText/reactive', 'foobar'), String
+        ).blockingFirst()
+
+        then:
+        response.contentType.isPresent()
+        response.contentType.get() == MediaType.TEXT_PLAIN_TYPE
+        response.body() == 'Body: foobar'
+    }
+
+    @Requires(property = 'spec.name', value = 'TomcatContentTypeSpec')
+    @Controller('/contentType/default')
+    static class DefaultContentTypeController extends ContentTypeControllerBase {
+        @Post('/simple')
+        String simple(@Body String text) {
+            result(text)
+        }
+        @Post('/response')
+        HttpResponse<String> response(@Body String text) {
+            HttpResponse<String>.ok(result(text))
+        }
+        @Post('/reactive')
+        Single<String> reactive(@Body String text) {
+            Single<String>.just(result(text))
+        }
+    }
+
+    @Requires(property = 'spec.name', value = 'TomcatContentTypeSpec')
+    @Controller('/contentType/plainText')
+    @Produces(MediaType.TEXT_PLAIN)
+    static class PlainTextContentTypeController extends ContentTypeControllerBase {
+        @Post('/simple')
+        String simple(@Body String text) {
+            result(text)
+        }
+        @Post('/response')
+        HttpResponse<String> response(@Body String text) {
+            HttpResponse<String>.ok(result(text))
+        }
+        @Post('/reactive')
+        Single<String> reactive(@Body String text) {
+            Single<String>.just(result(text))
+        }
+    }
+
+    private static class ContentTypeControllerBase {
+        @SuppressWarnings('GrMethodMayBeStatic')
+        String result(String text) {
+            "Body: $text"
+        }
+    }
+
+}

--- a/http-server-tomcat/src/test/groovy/io/micronaut/servlet/tomcat/TomcatContentTypeSpec.groovy
+++ b/http-server-tomcat/src/test/groovy/io/micronaut/servlet/tomcat/TomcatContentTypeSpec.groovy
@@ -7,12 +7,14 @@ import io.micronaut.http.HttpResponse
 import io.micronaut.http.MediaType
 import io.micronaut.http.annotation.Body
 import io.micronaut.http.annotation.Controller
+import io.micronaut.http.annotation.Get
 import io.micronaut.http.annotation.Post
 import io.micronaut.http.annotation.Produces
 import io.micronaut.http.client.RxHttpClient
 import io.micronaut.http.client.annotation.Client
 import io.micronaut.test.extensions.spock.annotation.MicronautTest
 import io.reactivex.Single
+import spock.lang.Issue
 import spock.lang.Specification
 
 import javax.inject.Inject
@@ -25,6 +27,17 @@ class TomcatContentTypeSpec extends Specification {
     @Client('/contentType')
     RxHttpClient client
 
+    @Issue('https://github.com/micronaut-projects/micronaut-servlet/issues/157')
+    void 'test that expected content-type is received'() {
+        when:
+        def response = client.exchange(HttpRequest.GET('/about')).blockingFirst()
+
+        then:
+        response.contentType.isPresent()
+        response.contentType.get() == MediaType.APPLICATION_JSON_TYPE
+    }
+
+    @Issue('https://github.com/micronaut-projects/micronaut-servlet/issues/206')
     void 'test that method returning String without @Produces will have JSON response content-type'() {
         when:
         def response = client.exchange(
@@ -37,6 +50,7 @@ class TomcatContentTypeSpec extends Specification {
         response.body() == 'Body: foobar'
     }
 
+    @Issue('https://github.com/micronaut-projects/micronaut-servlet/issues/206')
     void 'test that method returning HttpResponse without @Produces will have JSON response content-type'() {
         when:
         def response = client.exchange(
@@ -49,6 +63,7 @@ class TomcatContentTypeSpec extends Specification {
         response.body() == 'Body: foobar'
     }
 
+    @Issue('https://github.com/micronaut-projects/micronaut-servlet/issues/206')
     void 'test that method returning Single without @Produces will have JSON response content-type'() {
         when:
         def response = client.exchange(
@@ -61,6 +76,7 @@ class TomcatContentTypeSpec extends Specification {
         response.body() == 'Body: foobar'
     }
 
+    @Issue('https://github.com/micronaut-projects/micronaut-servlet/issues/206')
     void 'test that method returning String with @Produces TEXT_PLAIN will have text response content-type'() {
         when:
         def response = client.exchange(
@@ -73,6 +89,7 @@ class TomcatContentTypeSpec extends Specification {
         response.body() == 'Body: foobar'
     }
 
+    @Issue('https://github.com/micronaut-projects/micronaut-servlet/issues/206')
     void 'test that method returning HttpResponse with @Produces TEXT_PLAIN will have text response content-type'() {
         when:
         def response = client.exchange(
@@ -85,6 +102,7 @@ class TomcatContentTypeSpec extends Specification {
         response.body() == 'Body: foobar'
     }
 
+    @Issue('https://github.com/micronaut-projects/micronaut-servlet/issues/206')
     void 'test that method returning Single with @Produces TEXT_PLAIN will have text response content-type'() {
         when:
         def response = client.exchange(
@@ -95,6 +113,16 @@ class TomcatContentTypeSpec extends Specification {
         response.contentType.isPresent()
         response.contentType.get() == MediaType.TEXT_PLAIN_TYPE
         response.body() == 'Body: foobar'
+    }
+
+    @Requires(property = 'spec.name', value = 'TomcatContentTypeSpec')
+    @Controller("/contentType/about")
+    static class AboutController {
+        @Get
+        @Produces(MediaType.APPLICATION_JSON)
+        HttpResponse<String> index() {
+            HttpResponse.ok().body("OK")
+        }
     }
 
     @Requires(property = 'spec.name', value = 'TomcatContentTypeSpec')

--- a/http-server-tomcat/src/test/java/io/micronaut/servlet/tomcat/ParametersController.java
+++ b/http-server-tomcat/src/test/java/io/micronaut/servlet/tomcat/ParametersController.java
@@ -16,21 +16,25 @@ import java.io.*;
 public class ParametersController {
 
     @Get("/uri/{name}")
+    @Produces(MediaType.TEXT_PLAIN)
     String uriParam(String name) {
         return "Hello " + name;
     }
 
     @Get("/query")
+    @Produces(MediaType.TEXT_PLAIN)
     String queryValue(@QueryValue("q") String name) {
         return "Hello " + name;
     }
 
     @Get("/allParams")
+    @Produces(MediaType.TEXT_PLAIN)
     String allParams(HttpParameters parameters) {
         return "Hello " + parameters.get("name") + " " + parameters.get("age", int.class).orElse(null);
     }
 
     @Get("/header")
+    @Produces(MediaType.TEXT_PLAIN)
     String headerValue(@Header(HttpHeaders.CONTENT_TYPE) String contentType) {
         return "Hello " + contentType;
     }
@@ -53,6 +57,7 @@ public class ParametersController {
 
     @Post("/stringBody")
     @Consumes("text/plain")
+    @Produces(MediaType.TEXT_PLAIN)
     String stringBody(@Body String body) {
         return "Hello " + body;
     }

--- a/http-server-tomcat/src/test/java/io/micronaut/servlet/tomcat/ParametersController.java
+++ b/http-server-tomcat/src/test/java/io/micronaut/servlet/tomcat/ParametersController.java
@@ -15,26 +15,22 @@ import java.io.*;
 @Controller("/parameters")
 public class ParametersController {
 
-    @Get("/uri/{name}")
-    @Produces(MediaType.TEXT_PLAIN)
+    @Get(value = "/uri/{name}", produces = MediaType.TEXT_PLAIN)
     String uriParam(String name) {
         return "Hello " + name;
     }
 
-    @Get("/query")
-    @Produces(MediaType.TEXT_PLAIN)
+    @Get(value = "/query", produces = MediaType.TEXT_PLAIN)
     String queryValue(@QueryValue("q") String name) {
         return "Hello " + name;
     }
 
-    @Get("/allParams")
-    @Produces(MediaType.TEXT_PLAIN)
+    @Get(value = "/allParams", produces = MediaType.TEXT_PLAIN)
     String allParams(HttpParameters parameters) {
         return "Hello " + parameters.get("name") + " " + parameters.get("age", int.class).orElse(null);
     }
 
-    @Get("/header")
-    @Produces(MediaType.TEXT_PLAIN)
+    @Get(value = "/header", produces = MediaType.TEXT_PLAIN)
     String headerValue(@Header(HttpHeaders.CONTENT_TYPE) String contentType) {
         return "Hello " + contentType;
     }
@@ -55,30 +51,27 @@ public class ParametersController {
         }
     }
 
-    @Post("/stringBody")
-    @Consumes("text/plain")
-    @Produces(MediaType.TEXT_PLAIN)
+    @Post(value = "/stringBody", processes = MediaType.TEXT_PLAIN)
     String stringBody(@Body String body) {
         return "Hello " + body;
     }
 
-    @Post("/bytesBody")
-    @Consumes("text/plain")
+    @Post(value = "/bytesBody",processes = MediaType.TEXT_PLAIN)
     String bytesBody(@Body byte[] body) {
         return "Hello " + new String(body);
     }
 
-    @Post(value = "/jsonBody", processes = "application/json")
+    @Post(value = "/jsonBody", processes = MediaType.APPLICATION_JSON)
     Person jsonBody(@Body Person body) {
         return body;
     }
 
-    @Post(value = "/jsonBodySpread", processes = "application/json")
+    @Post(value = "/jsonBodySpread", processes = MediaType.APPLICATION_JSON)
     Person jsonBody(String name, int age) {
         return new Person(name, age);
     }
 
-    @Post(value = "/fullRequest", processes = "application/json")
+    @Post(value = "/fullRequest", processes = MediaType.APPLICATION_JSON)
     io.micronaut.http.HttpResponse<Person> fullReq(io.micronaut.http.HttpRequest<Person> request) {
         final Person person = request.getBody().orElseThrow(() -> new RuntimeException("No body"));
         final MutableHttpResponse<Person> response = io.micronaut.http.HttpResponse.ok(person);
@@ -86,7 +79,7 @@ public class ParametersController {
         return response;
     }
 
-    @Post(value = "/writable", processes = "text/plain")
+    @Post(value = "/writable", processes = MediaType.TEXT_PLAIN)
     @Header(name = "Foo", value = "Bar")
     @Status(HttpStatus.CREATED)
     Writable fullReq(@Body Readable readable) throws IOException {
@@ -98,8 +91,7 @@ public class ParametersController {
 
     }
 
-
-    @Post(value = "/multipart", consumes = MediaType.MULTIPART_FORM_DATA, produces = "text/plain")
+    @Post(value = "/multipart", consumes = MediaType.MULTIPART_FORM_DATA, produces = MediaType.TEXT_PLAIN)
     String multipart(
             String foo,
             @Part("one") Person person,

--- a/http-server-undertow/src/test/groovy/io/micronaut/servlet/undertow/UndertowContentTypeSpec.groovy
+++ b/http-server-undertow/src/test/groovy/io/micronaut/servlet/undertow/UndertowContentTypeSpec.groovy
@@ -1,0 +1,142 @@
+package io.micronaut.servlet.undertow
+
+import io.micronaut.context.annotation.Property
+import io.micronaut.context.annotation.Requires
+import io.micronaut.http.HttpRequest
+import io.micronaut.http.HttpResponse
+import io.micronaut.http.MediaType
+import io.micronaut.http.annotation.Body
+import io.micronaut.http.annotation.Controller
+import io.micronaut.http.annotation.Post
+import io.micronaut.http.annotation.Produces
+import io.micronaut.http.client.RxHttpClient
+import io.micronaut.http.client.annotation.Client
+import io.micronaut.test.extensions.spock.annotation.MicronautTest
+import io.reactivex.Single
+import spock.lang.Specification
+
+import javax.inject.Inject
+
+@MicronautTest
+@Property(name = 'spec.name', value = 'UndertowContentTypeSpec')
+class UndertowContentTypeSpec extends Specification {
+
+    @Inject
+    @Client('/contentType')
+    RxHttpClient client
+
+    void 'test that method returning String without @Produces will have JSON response content-type'() {
+        when:
+        def response = client.exchange(
+                HttpRequest.POST('/default/simple', 'foobar'), String
+        ).blockingFirst()
+
+        then:
+        response.contentType.isPresent()
+        response.contentType.get() == MediaType.APPLICATION_JSON_TYPE
+        response.body() == 'Body: foobar'
+    }
+
+    void 'test that method returning HttpResponse without @Produces will have JSON response content-type'() {
+        when:
+        def response = client.exchange(
+                HttpRequest.POST('/default/response', 'foobar'), String
+        ).blockingFirst()
+
+        then:
+        response.contentType.isPresent()
+        response.contentType.get() == MediaType.APPLICATION_JSON_TYPE
+        response.body() == 'Body: foobar'
+    }
+
+    void 'test that method returning Single without @Produces will have JSON response content-type'() {
+        when:
+        def response = client.exchange(
+                HttpRequest.POST('/default/reactive', 'foobar'), String
+        ).blockingFirst()
+
+        then:
+        response.contentType.isPresent()
+        response.contentType.get() == MediaType.APPLICATION_JSON_TYPE
+        response.body() == 'Body: foobar'
+    }
+
+    void 'test that method returning String with @Produces TEXT_PLAIN will have text response content-type'() {
+        when:
+        def response = client.exchange(
+                HttpRequest.POST('/plainText/simple', 'foobar'), String
+        ).blockingFirst()
+
+        then:
+        response.contentType.isPresent()
+        response.contentType.get() == MediaType.TEXT_PLAIN_TYPE
+        response.body() == 'Body: foobar'
+    }
+
+    void 'test that method returning HttpResponse with @Produces TEXT_PLAIN will have text response content-type'() {
+        when:
+        def response = client.exchange(
+                HttpRequest.POST('/plainText/response', 'foobar'), String
+        ).blockingFirst()
+
+        then:
+        response.contentType.isPresent()
+        response.contentType.get() == MediaType.TEXT_PLAIN_TYPE
+        response.body() == 'Body: foobar'
+    }
+
+    void 'test that method returning Single with @Produces TEXT_PLAIN will have text response content-type'() {
+        when:
+        def response = client.exchange(
+                HttpRequest.POST('/plainText/reactive', 'foobar'), String
+        ).blockingFirst()
+
+        then:
+        response.contentType.isPresent()
+        response.contentType.get() == MediaType.TEXT_PLAIN_TYPE
+        response.body() == 'Body: foobar'
+    }
+
+    @Requires(property = 'spec.name', value = 'UndertowContentTypeSpec')
+    @Controller('/contentType/default')
+    static class DefaultContentTypeController extends ContentTypeControllerBase {
+        @Post('/simple')
+        String simple(@Body String text) {
+            result(text)
+        }
+        @Post('/response')
+        HttpResponse<String> response(@Body String text) {
+            HttpResponse<String>.ok(result(text))
+        }
+        @Post('/reactive')
+        Single<String> reactive(@Body String text) {
+            Single<String>.just(result(text))
+        }
+    }
+
+    @Requires(property = 'spec.name', value = 'UndertowContentTypeSpec')
+    @Controller('/contentType/plainText')
+    @Produces(MediaType.TEXT_PLAIN)
+    static class PlainTextContentTypeController extends ContentTypeControllerBase {
+        @Post('/simple')
+        String simple(@Body String text) {
+            result(text)
+        }
+        @Post('/response')
+        HttpResponse<String> response(@Body String text) {
+            HttpResponse<String>.ok(result(text))
+        }
+        @Post('/reactive')
+        Single<String> reactive(@Body String text) {
+            Single<String>.just(result(text))
+        }
+    }
+
+    private static class ContentTypeControllerBase {
+        @SuppressWarnings('GrMethodMayBeStatic')
+        String result(String text) {
+            "Body: $text"
+        }
+    }
+
+}

--- a/http-server-undertow/src/test/groovy/io/micronaut/servlet/undertow/UndertowContentTypeSpec.groovy
+++ b/http-server-undertow/src/test/groovy/io/micronaut/servlet/undertow/UndertowContentTypeSpec.groovy
@@ -13,12 +13,14 @@ import io.micronaut.http.client.RxHttpClient
 import io.micronaut.http.client.annotation.Client
 import io.micronaut.test.extensions.spock.annotation.MicronautTest
 import io.reactivex.Single
+import spock.lang.Issue
 import spock.lang.Specification
 
 import javax.inject.Inject
 
 @MicronautTest
 @Property(name = 'spec.name', value = 'UndertowContentTypeSpec')
+@Issue('https://github.com/micronaut-projects/micronaut-servlet/issues/206')
 class UndertowContentTypeSpec extends Specification {
 
     @Inject

--- a/http-server-undertow/src/test/java/io/micronaut/servlet/undertow/ParametersController.java
+++ b/http-server-undertow/src/test/java/io/micronaut/servlet/undertow/ParametersController.java
@@ -14,26 +14,22 @@ import java.io.*;
 @Controller("/parameters")
 public class ParametersController {
 
-    @Get("/uri/{name}")
-    @Produces(MediaType.TEXT_PLAIN)
+    @Get(value = "/uri/{name}", produces = MediaType.TEXT_PLAIN)
     String uriParam(String name) {
         return "Hello " + name;
     }
 
-    @Get("/query")
-    @Produces(MediaType.TEXT_PLAIN)
+    @Get(value = "/query", produces = MediaType.TEXT_PLAIN)
     String queryValue(@QueryValue("q") String name) {
         return "Hello " + name;
     }
 
-    @Get("/allParams")
-    @Produces(MediaType.TEXT_PLAIN)
+    @Get(value = "/allParams", produces = MediaType.TEXT_PLAIN)
     String allParams(HttpParameters parameters) {
         return "Hello " + parameters.get("name") + " " + parameters.get("age", int.class).orElse(null);
     }
 
-    @Get("/header")
-    @Produces(MediaType.TEXT_PLAIN)
+    @Get(value = "/header", produces = MediaType.TEXT_PLAIN)
     String headerValue(@Header(HttpHeaders.CONTENT_TYPE) String contentType) {
         return "Hello " + contentType;
     }
@@ -54,30 +50,27 @@ public class ParametersController {
         }
     }
 
-    @Post("/stringBody")
-    @Consumes("text/plain")
-    @Produces(MediaType.TEXT_PLAIN)
+    @Post(value = "/stringBody", processes = MediaType.TEXT_PLAIN)
     String stringBody(@Body String body) {
         return "Hello " + body;
     }
 
-    @Post("/bytesBody")
-    @Consumes("text/plain")
+    @Post(value = "/bytesBody", processes = MediaType.TEXT_PLAIN)
     String bytesBody(@Body byte[] body) {
         return "Hello " + new String(body);
     }
 
-    @Post(value = "/jsonBody", processes = "application/json")
+    @Post(value = "/jsonBody", processes = MediaType.APPLICATION_JSON)
     Person jsonBody(@Body Person body) {
         return body;
     }
 
-    @Post(value = "/jsonBodySpread", processes = "application/json")
+    @Post(value = "/jsonBodySpread", processes = MediaType.APPLICATION_JSON)
     Person jsonBody(String name, int age) {
         return new Person(name, age);
     }
 
-    @Post(value = "/fullRequest", processes = "application/json")
+    @Post(value = "/fullRequest", processes = MediaType.APPLICATION_JSON)
     io.micronaut.http.HttpResponse<Person> fullReq(io.micronaut.http.HttpRequest<Person> request) {
         final Person person = request.getBody().orElseThrow(() -> new RuntimeException("No body"));
         final MutableHttpResponse<Person> response = io.micronaut.http.HttpResponse.ok(person);
@@ -85,15 +78,14 @@ public class ParametersController {
         return response;
     }
 
-    @Post(value = "/writable", processes = "text/plain")
+    @Post(value = "/writable", processes = MediaType.TEXT_PLAIN)
     @Header(name = "Foo", value = "Bar")
     @Status(HttpStatus.CREATED)
     Writable fullReq(@Body String text) {
         return out -> out.append("Hello ").append(text);
     }
 
-
-    @Post(value = "/multipart", consumes = MediaType.MULTIPART_FORM_DATA, produces = "text/plain")
+    @Post(value = "/multipart", consumes = MediaType.MULTIPART_FORM_DATA, produces = MediaType.TEXT_PLAIN)
     String multipart(
             String foo,
             @Part("one") Person person,

--- a/http-server-undertow/src/test/java/io/micronaut/servlet/undertow/ParametersController.java
+++ b/http-server-undertow/src/test/java/io/micronaut/servlet/undertow/ParametersController.java
@@ -15,21 +15,25 @@ import java.io.*;
 public class ParametersController {
 
     @Get("/uri/{name}")
+    @Produces(MediaType.TEXT_PLAIN)
     String uriParam(String name) {
         return "Hello " + name;
     }
 
     @Get("/query")
+    @Produces(MediaType.TEXT_PLAIN)
     String queryValue(@QueryValue("q") String name) {
         return "Hello " + name;
     }
 
     @Get("/allParams")
+    @Produces(MediaType.TEXT_PLAIN)
     String allParams(HttpParameters parameters) {
         return "Hello " + parameters.get("name") + " " + parameters.get("age", int.class).orElse(null);
     }
 
     @Get("/header")
+    @Produces(MediaType.TEXT_PLAIN)
     String headerValue(@Header(HttpHeaders.CONTENT_TYPE) String contentType) {
         return "Hello " + contentType;
     }
@@ -52,6 +56,7 @@ public class ParametersController {
 
     @Post("/stringBody")
     @Consumes("text/plain")
+    @Produces(MediaType.TEXT_PLAIN)
     String stringBody(@Body String body) {
         return "Hello " + body;
     }

--- a/servlet-core/src/main/java/io/micronaut/servlet/http/ServletHttpHandler.java
+++ b/servlet-core/src/main/java/io/micronaut/servlet/http/ServletHttpHandler.java
@@ -664,7 +664,7 @@ public abstract class ServletHttpHandler<Req, Res> implements AutoCloseable, Lif
         } else if (body instanceof CharSequence) {
             if (response instanceof MutableHttpResponse) {
                 if (!response.getContentType().isPresent()) {
-                    ((MutableHttpResponse<?>) response).contentType(MediaType.TEXT_PLAIN_TYPE);
+                    ((MutableHttpResponse<?>) response).contentType(MediaType.APPLICATION_JSON);
                 }
             }
             try (BufferedWriter writer = exchange.getResponse().getWriter()) {
@@ -745,9 +745,7 @@ public abstract class ServletHttpHandler<Req, Res> implements AutoCloseable, Lif
     }
 
     private String getDefaultMediaType(Object result) {
-        if (result instanceof CharSequence) {
-            return MediaType.TEXT_PLAIN;
-        } else if (result != null) {
+        if (result != null) {
             return MediaType.APPLICATION_JSON;
         }
         return null;

--- a/servlet-core/src/main/java/io/micronaut/servlet/http/ServletHttpHandler.java
+++ b/servlet-core/src/main/java/io/micronaut/servlet/http/ServletHttpHandler.java
@@ -727,8 +727,6 @@ public abstract class ServletHttpHandler<Req, Res> implements AutoCloseable, Lif
                     .orElse(getDefaultMediaType(result));
             if (contentType != null) {
                 res.contentType(contentType);
-            } else if (result instanceof CharSequence) {
-                res.contentType(MediaType.TEXT_PLAIN);
             }
         }
 

--- a/servlet-engine/src/main/java/io/micronaut/servlet/engine/DefaultServletHttpResponse.java
+++ b/servlet-engine/src/main/java/io/micronaut/servlet/engine/DefaultServletHttpResponse.java
@@ -23,6 +23,7 @@ import io.micronaut.core.convert.ConversionService;
 import io.micronaut.core.convert.value.MutableConvertibleValues;
 import io.micronaut.core.io.buffer.ByteBuffer;
 import io.micronaut.core.io.buffer.ReferenceCounted;
+import io.micronaut.core.type.Argument;
 import io.micronaut.core.util.ArrayUtils;
 import io.micronaut.http.*;
 import io.micronaut.http.annotation.Produces;
@@ -198,6 +199,11 @@ public class DefaultServletHttpResponse<B> implements ServletHttpResponse<HttpSe
                 }
             }
         }), BackpressureStrategy.ERROR);
+    }
+
+    @Override
+    public Optional<MediaType> getContentType() {
+        return ConversionService.SHARED.convert(delegate.getContentType(), Argument.of(MediaType.class));
     }
 
     @Override


### PR DESCRIPTION
Fixes #206 

Absent any `@Produces` annotations or similar, the default content type for controller methods returning `String` is now `application/json`, matching the documentation and netty behavior. Previously, the servlet engines were setting content type to `text/plain`.

This PR also works around some issues with Tomcat where attempting to get response's content type will fail.