### PR TITLE
Fix encode message

### DIFF
--- a/http-server-jetty/src/test/groovy/io/micronaut/servlet/jetty/JettyNotFoundSpec.groovy
+++ b/http-server-jetty/src/test/groovy/io/micronaut/servlet/jetty/JettyNotFoundSpec.groovy
@@ -1,45 +1,54 @@
 
 package io.micronaut.servlet.jetty
 
-import io.micronaut.context.ApplicationContext
+
+import io.micronaut.context.annotation.Property
 import io.micronaut.context.annotation.Requires
 import io.micronaut.http.MediaType
 import io.micronaut.http.annotation.Consumes
 import io.micronaut.http.annotation.Controller
 import io.micronaut.http.annotation.Get
+import io.micronaut.http.client.RxHttpClient
 import io.micronaut.http.client.annotation.Client
-import io.micronaut.runtime.server.EmbeddedServer
+import io.micronaut.http.client.exceptions.HttpClientResponseException
+import io.micronaut.http.hateoas.JsonError
+import io.micronaut.test.extensions.spock.annotation.MicronautTest
 import io.reactivex.Flowable
 import io.reactivex.Maybe
-import spock.lang.AutoCleanup
-import spock.lang.PendingFeature
-import spock.lang.Shared
 import spock.lang.Specification
 
+import javax.inject.Inject
+
+@MicronautTest
+@Property(name = 'spec.name', value = 'JettyNotFoundSpec')
 class JettyNotFoundSpec extends Specification {
 
-    @Shared @AutoCleanup EmbeddedServer embeddedServer = ApplicationContext.run(EmbeddedServer, [
-            'spec.name': 'JettyNotFoundSpec'
-    ])
+    @Inject
+    InventoryClient client
+
+    @Inject
+    @Client('/not-found')
+    RxHttpClient rxClient
 
     void "test 404 handling with Flowable"() {
-        given:
-        InventoryClient client = embeddedServer.getApplicationContext().getBean(InventoryClient)
-
         expect:
         client.flowable('1234').blockingFirst()
         client.flowable('notthere').toList().blockingGet() == []
-
     }
 
     void "test 404 handling with Maybe"() {
-        given:
-        InventoryClient client = embeddedServer.getApplicationContext().getBean(InventoryClient)
-
         expect:
         client.maybe('1234').blockingGet()
         client.maybe('notthere').blockingGet() == null
+    }
 
+    void "test 404 handling with Maybe and JsonError"() {
+        when:
+        rxClient.exchange('/maybe/notthere').blockingFirst()
+
+        then:
+        def t = thrown(HttpClientResponseException)
+        t.response.getBody(JsonError).get().message.contains 'Not Found'
     }
 
     @Requires(property = 'spec.name', value = 'JettyNotFoundSpec')
@@ -59,7 +68,6 @@ class JettyNotFoundSpec extends Specification {
         Map<String, Boolean> stock = [
                 '1234': true
         ]
-
 
         @Get('/maybe/{isbn}')
         Maybe<Boolean> maybe(String isbn) {

--- a/servlet-core/src/main/java/io/micronaut/servlet/http/ServletHttpHandler.java
+++ b/servlet-core/src/main/java/io/micronaut/servlet/http/ServletHttpHandler.java
@@ -419,6 +419,7 @@ public abstract class ServletHttpHandler<Req, Res> implements AutoCloseable, Lif
                                         MutableHttpResponse<Object> defaultNotFound = errorResponseProcessor.processResponse(
                                                 ErrorContext.builder(req).build(),
                                                 res.status(404));
+                                        encodeResponse(exchange, annotationMetadata, defaultNotFound);
                                         return Publishers.just(defaultNotFound);
                                     }
                                 }));


### PR DESCRIPTION
Found a particular case where the response was not being written out. Added the call to `encodeResponse` and modified the test to cover this case (which was not being tested before).