### PR TITLE
Make servletHttpHandler log errors as errors

### DIFF
--- a/servlet-core/src/main/java/io/micronaut/servlet/http/ServletHttpHandler.java
+++ b/servlet-core/src/main/java/io/micronaut/servlet/http/ServletHttpHandler.java
@@ -294,7 +294,7 @@ public abstract class ServletHttpHandler<Req, Res> implements AutoCloseable, Lif
                                         if (LOG.isDebugEnabled()) {
                                             LOG.debug("Request [{} - {}] completed successfully", req.getMethodName(), req.getUri());
                                         }
-                                    }, throwable -> LOG.error("Request [" + req.getMethodName() + " - " + req.getUri() + "] completed with error: " + throwable.getMessage(), throwable));
+                                    }, throwable -> LOG.error("Request [{} - {}] completed with error: {}", req.getMethodName(), req.getUri(), throwable.getMessage(), throwable));
                         } else {
                             try {
                                 encodeResponse(exchange, AnnotationMetadata.EMPTY_METADATA, res);
@@ -302,7 +302,7 @@ public abstract class ServletHttpHandler<Req, Res> implements AutoCloseable, Lif
                                     LOG.debug("Request [{} - {}] completed successfully", req.getMethodName(), req.getUri());
                                 }
                             } catch (Exception e) {
-                                LOG.error("Request [" + req.getMethodName() + " - " + req.getUri() + "] completed with error: " + e.getMessage(), e);
+                                LOG.error("Request [{} - {}] completed with error: {}", req.getMethodName(), req.getUri(), e.getMessage(), e);
                             }
                         }
                     } else {
@@ -511,7 +511,7 @@ public abstract class ServletHttpHandler<Req, Res> implements AutoCloseable, Lif
                         if (LOG.isDebugEnabled()) {
                             LOG.debug("Request [{} - {}] completed successfully", req.getMethodName(), req.getUri());
                         }
-                    }, throwable -> LOG.error("Request [" + req.getMethodName() + " - " + req.getUri() + "] completed with error: " + throwable.getMessage(), throwable));
+                    }, throwable -> LOG.error("Request [{} - {}] completed with error: {}", req.getMethodName(), req.getUri(), throwable.getMessage(), throwable));
         } else {
             responseFlux
                     .subscribeOn(Schedulers.immediate())
@@ -520,7 +520,7 @@ public abstract class ServletHttpHandler<Req, Res> implements AutoCloseable, Lif
                         if (LOG.isDebugEnabled()) {
                             LOG.debug("Request [{} - {}] completed successfully", req.getMethodName(), req.getUri());
                         }
-                    }, throwable -> LOG.error("Request [" + req.getMethodName() + " - " + req.getUri() + "] completed with error: " + throwable.getMessage(), throwable));
+                    }, throwable -> LOG.error("Request [{} - {}] completed with error: {}", req.getMethodName(), req.getUri(), throwable.getMessage(), throwable));
         }
     }
 

--- a/servlet-core/src/main/java/io/micronaut/servlet/http/ServletHttpHandler.java
+++ b/servlet-core/src/main/java/io/micronaut/servlet/http/ServletHttpHandler.java
@@ -294,11 +294,7 @@ public abstract class ServletHttpHandler<Req, Res> implements AutoCloseable, Lif
                                         if (LOG.isDebugEnabled()) {
                                             LOG.debug("Request [{} - {}] completed successfully", req.getMethodName(), req.getUri());
                                         }
-                                    }, throwable -> {
-                                        if (LOG.isDebugEnabled()) {
-                                            LOG.debug("Request [" + req.getMethodName() + " - " + req.getUri() + "] completed with error: " + throwable.getMessage(), throwable);
-                                        }
-                                    });
+                                    }, throwable -> LOG.error("Request [" + req.getMethodName() + " - " + req.getUri() + "] completed with error: " + throwable.getMessage(), throwable));
                         } else {
                             try {
                                 encodeResponse(exchange, AnnotationMetadata.EMPTY_METADATA, res);
@@ -306,9 +302,7 @@ public abstract class ServletHttpHandler<Req, Res> implements AutoCloseable, Lif
                                     LOG.debug("Request [{} - {}] completed successfully", req.getMethodName(), req.getUri());
                                 }
                             } catch (Exception e) {
-                                if (LOG.isDebugEnabled()) {
-                                    LOG.debug("Request [" + req.getMethodName() + " - " + req.getUri() + "] completed with error: " + e.getMessage(), e);
-                                }
+                                LOG.error("Request [" + req.getMethodName() + " - " + req.getUri() + "] completed with error: " + e.getMessage(), e);
                             }
                         }
                     } else {
@@ -517,11 +511,7 @@ public abstract class ServletHttpHandler<Req, Res> implements AutoCloseable, Lif
                         if (LOG.isDebugEnabled()) {
                             LOG.debug("Request [{} - {}] completed successfully", req.getMethodName(), req.getUri());
                         }
-                    }, throwable -> {
-                        if (LOG.isDebugEnabled()) {
-                            LOG.debug("Request [" + req.getMethodName() + " - " + req.getUri() + "] completed with error: " + throwable.getMessage(), throwable);
-                        }
-                    });
+                    }, throwable -> LOG.error("Request [" + req.getMethodName() + " - " + req.getUri() + "] completed with error: " + throwable.getMessage(), throwable));
         } else {
             responseFlux
                     .subscribeOn(Schedulers.immediate())
@@ -530,11 +520,7 @@ public abstract class ServletHttpHandler<Req, Res> implements AutoCloseable, Lif
                         if (LOG.isDebugEnabled()) {
                             LOG.debug("Request [{} - {}] completed successfully", req.getMethodName(), req.getUri());
                         }
-                    }, throwable -> {
-                        if (LOG.isDebugEnabled()) {
-                            LOG.debug("Request [" + req.getMethodName() + " - " + req.getUri() + "] completed with error: " + throwable.getMessage(), throwable);
-                        }
-                    });
+                    }, throwable -> LOG.error("Request [" + req.getMethodName() + " - " + req.getUri() + "] completed with error: " + throwable.getMessage(), throwable));
         }
     }
 


### PR DESCRIPTION
Changes:

- Server errors while processing a request are now logged at the error level:
- I also removed the log level check since:
  1. Nobody should be running his server with a log level below error, so in most cases it will take more time to check twice that the error should be logged
  2. It is shorter and easier on the eye.
  3. Using anchors should solve any performance penalty incurred if the logs don't actually need to be written. (https://www.slf4j.org/faq.html#logging_performance)

resolves #325

(create a new PR to see if I can solve SonarQube by creating the PR from a branch)