### PR TITLE
Update version for next Major and fix config

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
-projectVersion=3.3.2-SNAPSHOT
+projectVersion=4.0.0-SNAPSHOT
 projectGroup=io.micronaut.servlet
 
 micronautDocsVersion=2.0.0

--- a/http-server-jetty/src/main/java/io/micronaut/servlet/jetty/JettyConfiguration.java
+++ b/http-server-jetty/src/main/java/io/micronaut/servlet/jetty/JettyConfiguration.java
@@ -17,6 +17,7 @@ package io.micronaut.servlet.jetty;
 
 import io.micronaut.context.annotation.ConfigurationBuilder;
 import io.micronaut.context.annotation.ConfigurationProperties;
+import io.micronaut.context.annotation.Replaces;
 import io.micronaut.core.convert.format.MapFormat;
 import io.micronaut.core.naming.conventions.StringConvention;
 import io.micronaut.http.server.HttpServerConfiguration;
@@ -36,6 +37,7 @@ import java.util.Optional;
  * @since 1.0.0
  */
 @ConfigurationProperties("jetty")
+@Replaces(HttpServerConfiguration.class)
 public class JettyConfiguration extends HttpServerConfiguration {
 
     @ConfigurationBuilder

--- a/http-server-tomcat/src/main/java/io/micronaut/servlet/tomcat/TomcatConfiguration.java
+++ b/http-server-tomcat/src/main/java/io/micronaut/servlet/tomcat/TomcatConfiguration.java
@@ -18,6 +18,7 @@ package io.micronaut.servlet.tomcat;
 import io.micronaut.context.annotation.ConfigurationBuilder;
 import io.micronaut.context.annotation.ConfigurationProperties;
 import io.micronaut.context.annotation.Property;
+import io.micronaut.context.annotation.Replaces;
 import io.micronaut.core.annotation.TypeHint;
 import io.micronaut.core.convert.format.MapFormat;
 import io.micronaut.core.naming.conventions.StringConvention;
@@ -53,6 +54,7 @@ import java.util.Optional;
         AjpNio2Protocol.class,
         AjpNioProtocol.class
 })
+@Replaces(HttpServerConfiguration.class)
 public class TomcatConfiguration extends HttpServerConfiguration {
 
     @ConfigurationBuilder

--- a/http-server-undertow/src/main/java/io/micronaut/servlet/undertow/UndertowConfiguration.java
+++ b/http-server-undertow/src/main/java/io/micronaut/servlet/undertow/UndertowConfiguration.java
@@ -17,6 +17,7 @@ package io.micronaut.servlet.undertow;
 
 import io.micronaut.context.annotation.ConfigurationBuilder;
 import io.micronaut.context.annotation.ConfigurationProperties;
+import io.micronaut.context.annotation.Replaces;
 import io.micronaut.core.annotation.TypeHint;
 import io.micronaut.core.convert.format.MapFormat;
 import io.micronaut.core.naming.conventions.StringConvention;
@@ -40,6 +41,7 @@ import java.util.Optional;
         value = {UndertowOptions.class, org.xnio.Option.class},
         accessType = TypeHint.AccessType.ALL_DECLARED_FIELDS
 )
+@Replaces(HttpServerConfiguration.class)
 public class UndertowConfiguration extends HttpServerConfiguration {
 
     @ConfigurationBuilder


### PR DESCRIPTION
When we switched to 4.0.x we didn't update the major version.

Also, with the latest snapshot, we had failures due to

Message: Multiple possible bean candidates found: [JettyConfiguration, HttpServerConfiguration]

This PR annotates the 3 server config with Replaces