### PR TITLE
Fix Servlet binding for Publisher types

### DIFF
--- a/http-server-jetty/src/test/groovy/io/micronaut/servlet/jetty/JettyHttpPostSpec.groovy
+++ b/http-server-jetty/src/test/groovy/io/micronaut/servlet/jetty/JettyHttpPostSpec.groovy
@@ -5,6 +5,7 @@ import groovy.transform.EqualsAndHashCode
 import io.micronaut.context.annotation.Property
 import io.micronaut.context.annotation.Requires
 import io.micronaut.core.annotation.Introspected
+import io.micronaut.core.async.annotation.SingleResult
 import io.micronaut.core.type.Argument
 import io.micronaut.core.util.StringUtils
 import io.micronaut.http.HttpRequest
@@ -14,12 +15,12 @@ import io.micronaut.http.MediaType
 import io.micronaut.http.annotation.*
 import io.micronaut.http.client.HttpClient
 import io.micronaut.http.client.annotation.Client
-import io.micronaut.http.client.exceptions.HttpClientException
 import io.micronaut.http.client.exceptions.HttpClientResponseException
 import io.micronaut.http.client.multipart.MultipartBody
 import io.micronaut.http.multipart.CompletedFileUpload
 import io.micronaut.test.extensions.spock.annotation.MicronautTest
 import jakarta.inject.Inject
+import org.reactivestreams.Publisher
 import spock.lang.Specification
 
 import java.nio.charset.StandardCharsets
@@ -334,6 +335,38 @@ class JettyHttpPostSpec extends Specification {
         val == "multiple mappings"
     }
 
+    void 'test posting publisher with #desc'() {
+        when:
+        String data = client.toBlocking().retrieve(
+                HttpRequest.POST("/post/publisher", body),
+                String
+        )
+
+        then:
+        data == expected
+
+        where:
+        body                                                                     | expected                                                                 | desc
+        '[{"title":"some book","pages":1},{"title":"necronomicon","pages":666}]' | '[{"title":"some book","pages":1},{"title":"necronomicon","pages":666}]' | 'multiple entries'
+        '{"title":"some book","pages":1}'                                        | '[{"title":"some book","pages":1}]'                                      | 'single entry'
+    }
+
+    void 'test @SingleResult publisher with #desc'() {
+        when:
+        String data = client.toBlocking().retrieve(
+                HttpRequest.POST("/post/single-publisher", body),
+                String
+        )
+
+        then:
+        data == expected
+
+        where:
+        body                                                                     | expected                          | desc
+        '[{"title":"some book","pages":1},{"title":"necronomicon","pages":666}]' | '{"title":"some book","pages":1}' | 'multiple entries'
+        '{"title":"some book","pages":1}'                                        | '{"title":"some book","pages":1}' | 'single entry'
+    }
+
     @Requires(property = 'spec.name', value = 'JettyHttpPostSpec')
     @Controller('/post')
     static class PostController {
@@ -367,6 +400,17 @@ class JettyHttpPostSpec extends Specification {
         @Post('/noBody')
         String noBody(@Header("Content-Length") String contentLength) {
             return contentLength
+        }
+
+        @Post('/publisher')
+        Publisher<Book> publisher(@Body Publisher<Book> bookPublisher) {
+            return bookPublisher
+        }
+
+        @Post('/single-publisher')
+        @SingleResult
+        Publisher<Book> singlePublisher(@Body Publisher<Book> bookPublisher) {
+            return bookPublisher
         }
 
         @Post('/title/{title}')

--- a/servlet-core/src/main/java/io/micronaut/servlet/http/ServletHttpHandler.java
+++ b/servlet-core/src/main/java/io/micronaut/servlet/http/ServletHttpHandler.java
@@ -93,8 +93,9 @@ public abstract class ServletHttpHandler<REQ, RES> implements AutoCloseable, Lif
      * Default constructor.
      *
      * @param applicationContext The application context
+     * @param conversionService  The conversion service
      */
-    public ServletHttpHandler(ApplicationContext applicationContext, ConversionService conversionService) {
+    protected ServletHttpHandler(ApplicationContext applicationContext, ConversionService conversionService) {
         this.applicationContext = Objects.requireNonNull(applicationContext, "The application context cannot be null");
         this.mediaTypeCodecRegistry = applicationContext.getBean(MediaTypeCodecRegistry.class);
         //noinspection unchecked

--- a/servlet-engine/src/main/java/io/micronaut/servlet/engine/DefaultServletHttpHandler.java
+++ b/servlet-engine/src/main/java/io/micronaut/servlet/engine/DefaultServletHttpHandler.java
@@ -16,6 +16,7 @@
 package io.micronaut.servlet.engine;
 
 import io.micronaut.context.ApplicationContext;
+import io.micronaut.core.convert.ConversionService;
 import io.micronaut.servlet.http.ServletExchange;
 import io.micronaut.servlet.http.ServletHttpHandler;
 
@@ -36,8 +37,8 @@ public class DefaultServletHttpHandler extends ServletHttpHandler<HttpServletReq
      *
      * @param applicationContext The application context
      */
-    public DefaultServletHttpHandler(ApplicationContext applicationContext) {
-        super(applicationContext);
+    public DefaultServletHttpHandler(ApplicationContext applicationContext, ConversionService conversionService) {
+        super(applicationContext, conversionService);
     }
 
     @Override

--- a/servlet-engine/src/main/java/io/micronaut/servlet/engine/DefaultServletHttpHandler.java
+++ b/servlet-engine/src/main/java/io/micronaut/servlet/engine/DefaultServletHttpHandler.java
@@ -36,6 +36,7 @@ public class DefaultServletHttpHandler extends ServletHttpHandler<HttpServletReq
      * Default constructor.
      *
      * @param applicationContext The application context
+     * @param conversionService  The conversion service
      */
     public DefaultServletHttpHandler(ApplicationContext applicationContext, ConversionService conversionService) {
         super(applicationContext, conversionService);

--- a/servlet-engine/src/main/java/io/micronaut/servlet/engine/bind/DefaultServletBinderRegistry.java
+++ b/servlet-engine/src/main/java/io/micronaut/servlet/engine/bind/DefaultServletBinderRegistry.java
@@ -161,7 +161,7 @@ class DefaultServletBinderRegistry extends io.micronaut.servlet.http.ServletBind
                         if (type.isInstance(stringFlux)) {
                             return () -> Optional.of(stringFlux);
                         } else {
-                            Object converted = Publishers.convertPublisher(stringFlux, type);
+                            Object converted = Publishers.convertPublisher(conversionService, stringFlux, type);
                             return () -> Optional.of(converted);
                         }
                     } else if (byte[].class.isAssignableFrom(javaArgument)) {
@@ -170,8 +170,9 @@ class DefaultServletBinderRegistry extends io.micronaut.servlet.http.ServletBind
                         MediaType mediaType = servletHttpRequest.getContentType().orElse(MediaType.APPLICATION_JSON_TYPE);
                         MapperMediaTypeCodec codec = (MapperMediaTypeCodec) mediaTypeCodecRegistry.findCodec(mediaType, javaArgument).orElse(null);
                         if (codec != null) {
-                            Processor<byte[], io.micronaut.json.tree.JsonNode> jsonProcessor = codec.getJsonMapper().createReactiveParser(servletHttpRequest::subscribe, false);
+                            Processor<byte[], io.micronaut.json.tree.JsonNode> jsonProcessor = codec.getJsonMapper().createReactiveParser(servletHttpRequest::subscribe, true);
                             Object converted = Publishers.convertPublisher(
+                                    conversionService,
                                     Flux.from(jsonProcessor)
                                         .map(jsonNode -> codec.decode(typeArgument, jsonNode)), type);
                             return () -> Optional.of(converted);


### PR DESCRIPTION
The main change here is to pass `true` for the streamArray argument here:

https://github.com/micronaut-projects/micronaut-servlet/blob/48b94e762eab16a0e0d315b423581a2b56591081/servlet-engine/src/main/java/io/micronaut/servlet/engine/bind/DefaultServletBinderRegistry.java#L173

Without it, when posting a json array of entries for the Publisher, we get a deserialization error:

```
15:28:49.660 [qtp1321185349-38] ERROR reactor.core.publisher.Operators - Operator called default onErrorDropped
reactor.core.Exceptions$ErrorCallbackNotImplemented: io.micronaut.http.codec.CodecException: Error decoding JSON stream for type [T]: Unexpected token START_ARRAY, expected START_OBJECT
 at [Source: UNKNOWN; byte offset: #UNKNOWN]
Caused by: io.micronaut.http.codec.CodecException: Error decoding JSON stream for type [T]: Unexpected token START_ARRAY, expected START_OBJECT
 at [Source: UNKNOWN; byte offset: #UNKNOWN]
```

I also passed the conversion service through the classes as it's now required for Publishers.convertPublisher in 4.0.0. At least, it's deprecated for removal without it.