### PR TITLE
Bind to localhost instead of 0.0.0.0

### DIFF
--- a/servlet-engine/src/main/java/io/micronaut/servlet/engine/server/ServletServerFactory.java
+++ b/servlet-engine/src/main/java/io/micronaut/servlet/engine/server/ServletServerFactory.java
@@ -158,7 +158,7 @@ public abstract class ServletServerFactory extends SslBuilder<SSLContext> {
     protected String getConfiguredHost() {
         return serverConfiguration
                 .getHost()
-                .orElseGet(() -> Optional.ofNullable(System.getenv("HOST")).orElse("0.0.0.0"));
+                .orElseGet(() -> Optional.ofNullable(System.getenv("HOST")).orElse(SocketUtils.LOCALHOST));
     }
 
     /**

--- a/src/main/docs/guide/breaks.adoc
+++ b/src/main/docs/guide/breaks.adoc
@@ -1,0 +1,10 @@
+This section documents breaking changes between versions.
+
+== 3.3.4
+
+=== Binding network interface
+
+Previously, the default servlet engine will bind to all network interfaces.
+This is a security risk.
+Now, the default servlet engine will bind to `localhost` only.
+To restore the original functionality, you need to configure `micronaut.server.host`, or set the `HOST` environment variable.

--- a/src/main/docs/guide/toc.yml
+++ b/src/main/docs/guide/toc.yml
@@ -6,4 +6,5 @@ jetty: Jetty Server
 tomcat: Tomcat Server
 undertow: Undertow Server
 faq: FAQ
+breaks: Breaking Changes
 repository: Repository


### PR DESCRIPTION
Previously, the servlet container was bound to all interfaces on 0.0.0.0

This change switches to bind to localhost by default as we dso with the Netty server.

It's a breaking change for security reasons, so I have raised it against 3.3.x.