### PR TITLE
Declare logback.xml as a resource for native

### DIFF
--- a/test-suite-http-server-tck-jetty/src/test/resources/META-INF/native-image/resource-config.json
+++ b/test-suite-http-server-tck-jetty/src/test/resources/META-INF/native-image/resource-config.json
@@ -3,6 +3,9 @@
     "includes": [
       {
         "pattern": "\\Qassets\\E"
+      },
+      {
+        "pattern": "\\Qlogback.xml\\E"
       }
     ]
   }

--- a/test-suite-http-server-tck-tomcat/src/test/resources/META-INF/native-image/resource-config.json
+++ b/test-suite-http-server-tck-tomcat/src/test/resources/META-INF/native-image/resource-config.json
@@ -3,6 +3,9 @@
     "includes": [
       {
         "pattern": "\\Qassets\\E"
+      },
+      {
+        "pattern": "\\Qlogback.xml\\E"
       }
     ]
   }

--- a/test-suite-http-server-tck-undertow/src/test/resources/META-INF/native-image/resource-config.json
+++ b/test-suite-http-server-tck-undertow/src/test/resources/META-INF/native-image/resource-config.json
@@ -3,6 +3,9 @@
     "includes": [
       {
         "pattern": "\\Qassets\\E"
+      },
+      {
+        "pattern": "\\Qlogback.xml\\E"
       }
     ]
   }


### PR DESCRIPTION
Without this, Tomcat logs at debug level, and Jetty and Undertow OOME when running nativeTest for the TCK