### PR TITLE
Pull in TCK test and fix for @Body('part')

### DIFF
--- a/servlet-core/src/main/java/io/micronaut/servlet/http/ServletBodyBinder.java
+++ b/servlet-core/src/main/java/io/micronaut/servlet/http/ServletBodyBinder.java
@@ -166,7 +166,7 @@ public class ServletBodyBinder<T> implements AnnotatedRequestArgumentBinder<Body
                     }
                     T content;
                     if (name != null) {
-                        Map decode = codec.decode(Map.class, inputStream);
+                        var decode = codec.decode(Map.class, inputStream);
                         content = conversionService.convert(decode.get(name), argument).orElse(null);
                     } else {
                         content = codec.decode(argument, inputStream);

--- a/servlet-core/src/main/java/io/micronaut/servlet/http/ServletBodyBinder.java
+++ b/servlet-core/src/main/java/io/micronaut/servlet/http/ServletBodyBinder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2020 original authors
+ * Copyright 2017-2023 original authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -42,6 +42,7 @@ import java.io.Reader;
 import java.lang.reflect.Array;
 import java.util.Collections;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 
 /**
@@ -163,7 +164,13 @@ public class ServletBodyBinder<T> implements AnnotatedRequestArgumentBinder<Body
                         Object[] array = content.toArray((Object[]) Array.newInstance(componentType, 0));
                         return () -> Optional.of((T) array);
                     }
-                    T content = codec.decode(argument, inputStream);
+                    T content;
+                    if (name != null) {
+                        Map decode = codec.decode(Map.class, inputStream);
+                        content = conversionService.convert(decode.get(name), argument).orElse(null);
+                    } else {
+                        content = codec.decode(argument, inputStream);
+                    }
                     return () -> Optional.of(content);
                 } catch (CodecException | IOException e) {
                     throw new CodecException("Unable to decode request body: " + e.getMessage(), e);

--- a/test-suite-http-server-tck-jetty/src/test/java/io/micronaut/http/server/tck/jetty/tests/BodyPartTest.java
+++ b/test-suite-http-server-tck-jetty/src/test/java/io/micronaut/http/server/tck/jetty/tests/BodyPartTest.java
@@ -1,0 +1,98 @@
+package io.micronaut.http.server.tck.jetty.tests;
+
+import io.micronaut.context.annotation.Requires;
+import io.micronaut.core.annotation.Introspected;
+import io.micronaut.http.HttpHeaders;
+import io.micronaut.http.HttpRequest;
+import io.micronaut.http.HttpStatus;
+import io.micronaut.http.MediaType;
+import io.micronaut.http.annotation.Body;
+import io.micronaut.http.annotation.Controller;
+import io.micronaut.http.annotation.Post;
+import io.micronaut.http.annotation.Status;
+import io.micronaut.http.tck.AssertionUtils;
+import io.micronaut.http.tck.HttpResponseAssertion;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.util.Objects;
+
+import static io.micronaut.http.tck.TestScenario.asserts;
+
+/**
+ * This is a new test in core
+ */
+
+class BodyPartTest {
+
+    public static final String SPEC_NAME = "BodyPartTest";
+
+    @Test
+    void testCustomBodyPOJOAsPart() throws IOException {
+        asserts(SPEC_NAME,
+            HttpRequest.POST("/response-body/part-pojo", "{\"point\":{\"x\":10,\"y\":20},\"foo\":\"bar\"}")
+                .header(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON),
+            (server, request) -> AssertionUtils.assertDoesNotThrow(server, request,
+                HttpResponseAssertion.builder()
+                    .status(HttpStatus.CREATED)
+                    .body("{\"x\":10,\"y\":20}")
+                    .build()));
+    }
+
+    @Controller("/response-body")
+    @Requires(property = "spec.name", value = SPEC_NAME)
+    static class BodyController {
+
+        @Post(uri = "/part-pojo")
+        @Status(HttpStatus.CREATED)
+        Point postPart(@Body("point") Point data) {
+            return data;
+        }
+    }
+
+    @Introspected
+    static class Point {
+        private Integer x;
+        private Integer y;
+
+        public Integer getX() {
+            return x;
+        }
+
+        public void setX(Integer x) {
+            this.x = x;
+        }
+
+        public Integer getY() {
+            return y;
+        }
+
+        public void setY(Integer y) {
+            this.y = y;
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) {
+                return true;
+            }
+            if (o == null || getClass() != o.getClass()) {
+                return false;
+            }
+
+            Point point = (Point) o;
+
+            if (!Objects.equals(x, point.x)) {
+                return false;
+            }
+            return Objects.equals(y, point.y);
+        }
+
+        @Override
+        public int hashCode() {
+            int result = x != null ? x.hashCode() : 0;
+            result = 31 * result + (y != null ? y.hashCode() : 0);
+            return result;
+        }
+    }
+}

--- a/test-suite-http-server-tck-jetty/src/test/java/io/micronaut/http/server/tck/jetty/tests/JettyHttpServerTestSuite.java
+++ b/test-suite-http-server-tck-jetty/src/test/java/io/micronaut/http/server/tck/jetty/tests/JettyHttpServerTestSuite.java
@@ -6,7 +6,10 @@ import org.junit.platform.suite.api.Suite;
 import org.junit.platform.suite.api.SuiteDisplayName;
 
 @Suite
-@SelectPackages("io.micronaut.http.server.tck.tests")
+@SelectPackages({
+    "io.micronaut.http.server.tck.tests",
+    "io.micronaut.http.server.tck.jetty.tests",
+})
 @SuiteDisplayName("HTTP Server TCK for Jetty")
 @ExcludeClassNamePatterns({
     "io.micronaut.http.server.tck.tests.staticresources.StaticResourceTest", // Graal fails to see /assets from the TCK as a resource https://ge.micronaut.io/s/ufuhtbe5sgmxi


### PR DESCRIPTION
A [new test has been added to the TCK in core](https://github.com/micronaut-projects/micronaut-core/commit/cb113ed18ca446e37c6bc795e86cdb9de4b8bc5d#diff-cbc26e04d777bd919b16dc101d49c4fdb2fbfbf0213b0a9ad242bf5377a754ef) that fails here in Servlet.

I'm not 100 sure this solution is right.  To support `@Body("part")`, if there's a name provided, I first convert to a map, and then pass the value of that map through the conversion service.

