### PR TITLE
Servlet Test failures after updating to M6

### DIFF
--- a/http-server-jetty/build.gradle
+++ b/http-server-jetty/build.gradle
@@ -8,5 +8,5 @@ dependencies {
     testCompileOnly(mnValidation.micronaut.validation.processor)
     testAnnotationProcessor(mnValidation.micronaut.validation.processor)
     testImplementation(mnValidation.micronaut.validation)
-    testImplementation(mn.micronaut.jackson.databind)
+    testImplementation(mnSerde.micronaut.serde.jackson)
 }

--- a/http-server-jetty/src/test/groovy/io/micronaut/servlet/jetty/JettyJsonBodyBindingSpec.groovy
+++ b/http-server-jetty/src/test/groovy/io/micronaut/servlet/jetty/JettyJsonBodyBindingSpec.groovy
@@ -25,7 +25,6 @@ import org.reactivestreams.Publisher
 import reactor.core.publisher.Flux
 import reactor.core.publisher.Mono
 import reactor.core.scheduler.Schedulers
-import spock.lang.PendingFeature
 import spock.lang.Specification
 
 import java.util.concurrent.CompletableFuture
@@ -74,8 +73,8 @@ class JettyJsonBodyBindingSpec extends Specification {
         response.body() == "Body: Foo(Fred, 10)"
     }
 
-    @PendingFeature
     void "test map-based body parsing with invalid JSON"() {
+
         when:
         def json = '{"title":The Stand}'
         rxClient.toBlocking().exchange(
@@ -288,7 +287,6 @@ class JettyJsonBodyBindingSpec extends Specification {
         response.body() == 'not found'
     }
 
-    @PendingFeature
     void "test request generic type conversion error"() {
         when:
         def json = '[1,2,3]'

--- a/http-server-jetty/src/test/groovy/io/micronaut/servlet/jetty/JettyJsonBodyBindingSpec2.groovy
+++ b/http-server-jetty/src/test/groovy/io/micronaut/servlet/jetty/JettyJsonBodyBindingSpec2.groovy
@@ -21,7 +21,6 @@ import io.micronaut.http.hateoas.JsonError
 import io.micronaut.http.hateoas.Link
 import io.micronaut.test.extensions.spock.annotation.MicronautTest
 import jakarta.inject.Inject
-import spock.lang.PendingFeature
 import spock.lang.Specification
 
 @MicronautTest
@@ -32,8 +31,8 @@ class JettyJsonBodyBindingSpec2 extends Specification {
     @Client("/")
     HttpClient rxClient
 
-    @PendingFeature
     void "test map-based body parsing with invalid JSON"() {
+
         when:
         rxClient.toBlocking().exchange(HttpRequest.POST('/json/map', '{"title":The Stand}'), String)
 

--- a/http-server-jetty/src/test/groovy/io/micronaut/servlet/jetty/JettyParameterBindingSpec.groovy
+++ b/http-server-jetty/src/test/groovy/io/micronaut/servlet/jetty/JettyParameterBindingSpec.groovy
@@ -14,7 +14,6 @@ import io.micronaut.http.client.HttpClient
 import io.micronaut.http.client.annotation.Client
 import io.micronaut.test.extensions.spock.annotation.MicronautTest
 import reactor.core.publisher.Mono
-import spock.lang.PendingFeature
 import spock.lang.Specification
 import spock.lang.Unroll
 
@@ -87,7 +86,6 @@ class JettyParameterBindingSpec extends Specification {
         HttpMethod.GET  | '/parameter/arrayStyle?param[]=a&param[]=b&param[]=c' | "Parameter Value: [a, b, c]"    | HttpStatus.OK
     }
 
-    @PendingFeature
     void "test list to single error"() {
         given:
         def req = HttpRequest.GET('/parameter/exploded?title=The%20Stand&age=20&age=30')

--- a/http-server-tomcat/build.gradle
+++ b/http-server-tomcat/build.gradle
@@ -5,6 +5,6 @@ plugins {
 dependencies {
     implementation libs.tomcat.embed.core
     testImplementation libs.bcpkix
-    testImplementation(mn.micronaut.jackson.databind)
+    testImplementation(mnSerde.micronaut.serde.jackson)
 }
 

--- a/http-server-tomcat/src/test/groovy/io/micronaut/servlet/tomcat/TomcatParameterBindingSpec.groovy
+++ b/http-server-tomcat/src/test/groovy/io/micronaut/servlet/tomcat/TomcatParameterBindingSpec.groovy
@@ -12,7 +12,6 @@ import io.micronaut.http.client.HttpClient
 import io.micronaut.http.client.annotation.Client
 import io.micronaut.test.extensions.spock.annotation.MicronautTest
 import reactor.core.publisher.Mono
-import spock.lang.PendingFeature
 import spock.lang.Specification
 import spock.lang.Unroll
 
@@ -80,7 +79,6 @@ class TomcatParameterBindingSpec extends Specification {
         HttpMethod.POST | '/parameter/query?name=Fr%20ed'                 | "Parameter Value: Fr ed"    | HttpStatus.OK
     }
 
-    @PendingFeature
     void "test list to single error"() {
         given:
         def req = HttpRequest.GET('/parameter/exploded?title=The%20Stand&age=20&age=30')

--- a/http-server-undertow/build.gradle
+++ b/http-server-undertow/build.gradle
@@ -5,5 +5,5 @@ plugins {
 dependencies {
     implementation libs.undertow.servlet
     testImplementation libs.bcpkix
-    testImplementation(mn.micronaut.jackson.databind)
+    testImplementation(mnSerde.micronaut.serde.jackson)
 }

--- a/http-server-undertow/src/test/groovy/io/micronaut/servlet/undertow/UndertowParameterBindingSpec.groovy
+++ b/http-server-undertow/src/test/groovy/io/micronaut/servlet/undertow/UndertowParameterBindingSpec.groovy
@@ -14,7 +14,6 @@ import io.micronaut.http.client.HttpClient
 import io.micronaut.http.client.annotation.Client
 import io.micronaut.test.extensions.spock.annotation.MicronautTest
 import reactor.core.publisher.Mono
-import spock.lang.PendingFeature
 import spock.lang.Specification
 import spock.lang.Unroll
 
@@ -83,7 +82,6 @@ class UndertowParameterBindingSpec extends Specification {
         HttpMethod.POST | '/parameter/query?name=Fr%20ed'                 | "Parameter Value: Fr ed"    | HttpStatus.OK
     }
 
-    @PendingFeature
     void "test list to single error"() {
         given:
         def req = HttpRequest.GET('/parameter/exploded?title=The%20Stand&age=20&age=30')

--- a/settings.gradle
+++ b/settings.gradle
@@ -18,6 +18,7 @@ micronautBuild {
     importMicronautCatalog()
     importMicronautCatalog("micronaut-reactor")
     importMicronautCatalog("micronaut-security")
+    importMicronautCatalog("micronaut-serde")
     importMicronautCatalog("micronaut-session")
     importMicronautCatalog("micronaut-validation")
     importMicronautCatalog("micronaut-logging")

--- a/test-suite-http-server-tck-jetty/src/test/java/io/micronaut/http/server/tck/jetty/tests/JettyHttpServerTestSuite.java
+++ b/test-suite-http-server-tck-jetty/src/test/java/io/micronaut/http/server/tck/jetty/tests/JettyHttpServerTestSuite.java
@@ -15,8 +15,7 @@ import org.junit.platform.suite.api.SuiteDisplayName;
     "io.micronaut.http.server.tck.tests.staticresources.StaticResourceTest", // Graal fails to see /assets from the TCK as a resource https://ge.micronaut.io/s/ufuhtbe5sgmxi
     "io.micronaut.http.server.tck.tests.filter.ClientResponseFilterTest", // responseFilterThrowableParameter fails under Graal https://ge.micronaut.io/s/ufuhtbe5sgmxi
     "io.micronaut.http.server.tck.tests.codec.JsonCodecAdditionalTypeTest", // remove once this pr is merged https://github.com/micronaut-projects/micronaut-core/pull/9308/files
-    "io.micronaut.http.server.tck.tests.constraintshandler.ControllerConstraintHandlerTest", // Bug accessing request body in @OnError
-    "io.micronaut.http.server.tck.tests.filter.RequestFilterTest"
+    "io.micronaut.http.server.tck.tests.constraintshandler.ControllerConstraintHandlerTest" // Bug accessing request body in @OnError
 })
 public class JettyHttpServerTestSuite {
 }

--- a/test-suite-http-server-tck-jetty/src/test/java/io/micronaut/http/server/tck/jetty/tests/JettyHttpServerTestSuite.java
+++ b/test-suite-http-server-tck-jetty/src/test/java/io/micronaut/http/server/tck/jetty/tests/JettyHttpServerTestSuite.java
@@ -15,7 +15,8 @@ import org.junit.platform.suite.api.SuiteDisplayName;
     "io.micronaut.http.server.tck.tests.staticresources.StaticResourceTest", // Graal fails to see /assets from the TCK as a resource https://ge.micronaut.io/s/ufuhtbe5sgmxi
     "io.micronaut.http.server.tck.tests.filter.ClientResponseFilterTest", // responseFilterThrowableParameter fails under Graal https://ge.micronaut.io/s/ufuhtbe5sgmxi
     "io.micronaut.http.server.tck.tests.codec.JsonCodecAdditionalTypeTest", // remove once this pr is merged https://github.com/micronaut-projects/micronaut-core/pull/9308/files
-    "io.micronaut.http.server.tck.tests.constraintshandler.ControllerConstraintHandlerTest" // Bug accessing request body in @OnError
+    "io.micronaut.http.server.tck.tests.constraintshandler.ControllerConstraintHandlerTest", // Bug accessing request body in @OnError
+    "io.micronaut.http.server.tck.tests.filter.RequestFilterTest", // Temporary disable tests until we get requestFilterBinding separated in the TCK (as it's testing anetty feature)
 })
 public class JettyHttpServerTestSuite {
 }

--- a/test-suite-http-server-tck-tomcat/src/test/java/io/micronaut/http/server/tck/tomcat/tests/TomcatHttpServerTestSuite.java
+++ b/test-suite-http-server-tck-tomcat/src/test/java/io/micronaut/http/server/tck/tomcat/tests/TomcatHttpServerTestSuite.java
@@ -12,7 +12,8 @@ import org.junit.platform.suite.api.SuiteDisplayName;
     "io.micronaut.http.server.tck.tests.staticresources.StaticResourceTest", // Graal fails to see /assets from the TCK as a resource https://ge.micronaut.io/s/ufuhtbe5sgmxi
     "io.micronaut.http.server.tck.tests.filter.ClientResponseFilterTest", // responseFilterThrowableParameter fails under Graal https://ge.micronaut.io/s/ufuhtbe5sgmxi
     "io.micronaut.http.server.tck.tests.codec.JsonCodecAdditionalTypeTest", // remove once this pr is merged https://github.com/micronaut-projects/micronaut-core/pull/9308/files
-    "io.micronaut.http.server.tck.tests.constraintshandler.ControllerConstraintHandlerTest" // Bug accessing request body in @OnError
+    "io.micronaut.http.server.tck.tests.constraintshandler.ControllerConstraintHandlerTest", // Bug accessing request body in @OnError
+    "io.micronaut.http.server.tck.tests.filter.RequestFilterTest", // Temporary disable tests until we get requestFilterBinding separated in the TCK (as it's testing anetty feature)
 })
 public class TomcatHttpServerTestSuite {
 }

--- a/test-suite-http-server-tck-tomcat/src/test/java/io/micronaut/http/server/tck/tomcat/tests/TomcatHttpServerTestSuite.java
+++ b/test-suite-http-server-tck-tomcat/src/test/java/io/micronaut/http/server/tck/tomcat/tests/TomcatHttpServerTestSuite.java
@@ -12,8 +12,7 @@ import org.junit.platform.suite.api.SuiteDisplayName;
     "io.micronaut.http.server.tck.tests.staticresources.StaticResourceTest", // Graal fails to see /assets from the TCK as a resource https://ge.micronaut.io/s/ufuhtbe5sgmxi
     "io.micronaut.http.server.tck.tests.filter.ClientResponseFilterTest", // responseFilterThrowableParameter fails under Graal https://ge.micronaut.io/s/ufuhtbe5sgmxi
     "io.micronaut.http.server.tck.tests.codec.JsonCodecAdditionalTypeTest", // remove once this pr is merged https://github.com/micronaut-projects/micronaut-core/pull/9308/files
-    "io.micronaut.http.server.tck.tests.constraintshandler.ControllerConstraintHandlerTest", // Bug accessing request body in @OnError
-    "io.micronaut.http.server.tck.tests.filter.RequestFilterTest"
+    "io.micronaut.http.server.tck.tests.constraintshandler.ControllerConstraintHandlerTest" // Bug accessing request body in @OnError
 })
 public class TomcatHttpServerTestSuite {
 }

--- a/test-suite-http-server-tck-undertow/src/test/java/io/micronaut/http/server/tck/undertow/tests/UndertowHttpServerTestSuite.java
+++ b/test-suite-http-server-tck-undertow/src/test/java/io/micronaut/http/server/tck/undertow/tests/UndertowHttpServerTestSuite.java
@@ -13,8 +13,7 @@ import org.junit.platform.suite.api.SuiteDisplayName;
     "io.micronaut.http.server.tck.tests.staticresources.StaticResourceTest", // Graal fails to see /assets from the TCK as a resource https://ge.micronaut.io/s/ufuhtbe5sgmxi
     "io.micronaut.http.server.tck.tests.filter.ClientResponseFilterTest", // responseFilterThrowableParameter fails under Graal https://ge.micronaut.io/s/ufuhtbe5sgmxi
     "io.micronaut.http.server.tck.tests.codec.JsonCodecAdditionalTypeTest", // remove once this pr is merged https://github.com/micronaut-projects/micronaut-core/pull/9308/files
-    "io.micronaut.http.server.tck.tests.constraintshandler.ControllerConstraintHandlerTest", // Bug accessing request body in @OnError
-    "io.micronaut.http.server.tck.tests.filter.RequestFilterTest"
+    "io.micronaut.http.server.tck.tests.constraintshandler.ControllerConstraintHandlerTest" // Bug accessing request body in @OnError
 })
 public class UndertowHttpServerTestSuite {
 }

--- a/test-suite-http-server-tck-undertow/src/test/java/io/micronaut/http/server/tck/undertow/tests/UndertowHttpServerTestSuite.java
+++ b/test-suite-http-server-tck-undertow/src/test/java/io/micronaut/http/server/tck/undertow/tests/UndertowHttpServerTestSuite.java
@@ -13,7 +13,8 @@ import org.junit.platform.suite.api.SuiteDisplayName;
     "io.micronaut.http.server.tck.tests.staticresources.StaticResourceTest", // Graal fails to see /assets from the TCK as a resource https://ge.micronaut.io/s/ufuhtbe5sgmxi
     "io.micronaut.http.server.tck.tests.filter.ClientResponseFilterTest", // responseFilterThrowableParameter fails under Graal https://ge.micronaut.io/s/ufuhtbe5sgmxi
     "io.micronaut.http.server.tck.tests.codec.JsonCodecAdditionalTypeTest", // remove once this pr is merged https://github.com/micronaut-projects/micronaut-core/pull/9308/files
-    "io.micronaut.http.server.tck.tests.constraintshandler.ControllerConstraintHandlerTest" // Bug accessing request body in @OnError
+    "io.micronaut.http.server.tck.tests.constraintshandler.ControllerConstraintHandlerTest", // Bug accessing request body in @OnError
+    "io.micronaut.http.server.tck.tests.filter.RequestFilterTest", // Temporary disable tests until we get requestFilterBinding separated in the TCK (as it's testing anetty feature)
 })
 public class UndertowHttpServerTestSuite {
 }


### PR DESCRIPTION
The following tests fail after updating to core M6.