### PR TITLE
Fix TCK ControllerConstraintHandlerTest

### DIFF
--- a/http-server-jetty/src/test/groovy/io/micronaut/servlet/jetty/JettyControllerConstraintHandlerSpec.groovy
+++ b/http-server-jetty/src/test/groovy/io/micronaut/servlet/jetty/JettyControllerConstraintHandlerSpec.groovy
@@ -1,0 +1,266 @@
+package io.micronaut.servlet.jetty
+
+import io.micronaut.context.annotation.Property
+import io.micronaut.context.annotation.Requires
+import io.micronaut.core.annotation.Introspected
+import io.micronaut.core.annotation.NonNull
+import io.micronaut.core.annotation.Nullable
+import io.micronaut.core.type.Argument
+import io.micronaut.http.HttpRequest
+import io.micronaut.http.HttpResponse
+import io.micronaut.http.HttpStatus
+import io.micronaut.http.MediaType
+import io.micronaut.http.annotation.Body
+import io.micronaut.http.annotation.Controller
+import io.micronaut.http.annotation.Error
+import io.micronaut.http.annotation.Post
+import io.micronaut.http.annotation.Produces
+import io.micronaut.http.annotation.Status
+import io.micronaut.http.client.HttpClient
+import io.micronaut.http.client.annotation.Client
+import io.micronaut.http.client.exceptions.HttpClientResponseException
+import io.micronaut.test.extensions.spock.annotation.MicronautTest
+import jakarta.inject.Inject
+import jakarta.validation.ConstraintViolationException
+import jakarta.validation.Valid
+import jakarta.validation.constraints.Email
+import jakarta.validation.constraints.NotBlank
+import jakarta.validation.constraints.NotNull
+import spock.lang.Specification
+
+@MicronautTest
+@Property(name = "spec.name", value = JettyControllerConstraintHandlerSpec.SPEC_NAME)
+class JettyControllerConstraintHandlerSpec extends Specification {
+
+    static final String SPEC_NAME = "JettyControllerConstraintHandlerSpec";
+
+    @Inject
+    @Client("/")
+    HttpClient client;
+
+    void "happy path"() {
+        when:
+        HttpRequest<?> post = HttpRequest.POST("/constraints-via-handler", '{"username":"tim@micronaut.example","password":"secret"}')
+        def exchange = request(post)
+
+        then:
+        exchange.status == HttpStatus.OK
+    }
+
+    void "invalid email with @nullable via handler"() {
+        when:
+        HttpRequest<?> post = HttpRequest.POST("/constraints-via-handler/with-at-nullable", '{"username":"invalidemail","password":"secret"}')
+        request(post)
+
+        then:
+        def e = thrown(HttpClientResponseException)
+        constraintAssertion(e.response, 'must be a well-formed email address')
+    }
+
+    void "blank email with @nullable via handler"() {
+        when:
+        HttpRequest<?> post = HttpRequest.POST("/constraints-via-handler/with-at-nullable", '{"username":"","password":"secret"}')
+        request(post)
+
+        then:
+        def e = thrown(HttpClientResponseException)
+        constraintAssertion(e.response, 'must not be blank')
+    }
+
+    void "blank email with @nullable via onError method"() {
+        when:
+        HttpRequest<?> post = HttpRequest.POST("/constraints-via-on-error-method/with-at-nullable", '{"username":"","password":"secret"}')
+        request(post)
+
+        then:
+        def e = thrown(HttpClientResponseException)
+        e.status == HttpStatus.I_AM_A_TEAPOT
+        e.response.getBody(String).get() == '{"password":"secret"}'
+    }
+
+    void "invalid email without @nullable via handler"() {
+        when:
+        HttpRequest<?> post = HttpRequest.POST("/constraints-via-handler", '{"username":"invalidemail","password":"secret"}')
+        request(post)
+
+        then:
+        def e = thrown(HttpClientResponseException)
+        constraintAssertion(e.response, 'must be a well-formed email address')
+    }
+
+    void "blank email without @nullable via handler"() {
+        when:
+        HttpRequest<?> post = HttpRequest.POST("/constraints-via-handler", '{"username":"","password":"secret"}')
+        request(post)
+
+        then:
+        def e = thrown(HttpClientResponseException)
+        constraintAssertion(e.response, 'must not be blank')
+    }
+
+    void "blank email without @nullable via onError method"() {
+        when:
+        HttpRequest<?> post = HttpRequest.POST("/constraints-via-on-error-method", '{"username":"","password":"secret"}')
+        request(post)
+
+        then:
+        def e = thrown(HttpClientResponseException)
+        e.status == HttpStatus.I_AM_A_TEAPOT
+        e.response.getBody(String).get() == '{"password":"secret"}'
+    }
+
+    private static constraintAssertion(HttpResponse<?> response, String expectedMessage, HttpStatus expectedStatus = HttpStatus.BAD_REQUEST) {
+        assert response.status == expectedStatus
+        assert response.getBody(Argument.of(Map)).get()._embedded.errors.any { it.message.contains(expectedMessage) }
+        true
+    }
+
+    def request(HttpRequest<?> req) {
+        client.toBlocking().exchange(req)
+    }
+
+    @Controller("/constraints-via-handler")
+    @Requires(property = "spec.name", value = SPEC_NAME)
+    static class BodyController {
+
+        @Post
+        @Produces(MediaType.TEXT_PLAIN)
+        @Status(HttpStatus.OK)
+        void login(@Body @NotNull @Valid CredentialsWithoutNullabilityAnnotation credentials) {
+        }
+
+        @Post("/with-at-nullable")
+        @Produces(MediaType.TEXT_PLAIN)
+        @Status(HttpStatus.OK)
+        void login(@Body @NotNull @Valid CredentialsWithNullable credentials) {
+        }
+
+        @Post("/with-non-null")
+        @Produces(MediaType.TEXT_PLAIN)
+        @Status(HttpStatus.OK)
+        void login(@Body @NotNull @Valid CredentialsWithNonNull credentials) {
+        }
+    }
+
+    @Controller("/constraints-via-on-error-method")
+    @Requires(property = "spec.name", value = SPEC_NAME)
+    static class OnErrorMethodController {
+
+        @Post
+        @Produces(MediaType.TEXT_PLAIN)
+        @Status(HttpStatus.OK)
+        void login(@Body @NotNull @Valid CredentialsWithoutNullabilityAnnotation credentials) {
+        }
+
+        @Post("/with-at-nullable")
+        @Produces(MediaType.TEXT_PLAIN)
+        @Status(HttpStatus.OK)
+        void loginWithNullable(@Body @NotNull @Valid CredentialsWithNullable credentials) {
+        }
+
+        @Post("/with-non-null")
+        @Produces(MediaType.TEXT_PLAIN)
+        @Status(HttpStatus.OK)
+        void loginWithNullable(@Body @NotNull @Valid CredentialsWithNonNull credentials) {
+        }
+
+        @Error(exception = ConstraintViolationException.class)
+        @Status(HttpStatus.I_AM_A_TEAPOT)
+        Optional<Map> constraintsEx(ConstraintViolationException e, HttpRequest<?> request) {
+
+            Optional<?> objectOptional = request.getBody();
+            if (objectOptional.isEmpty()) {
+                return Optional.empty();
+            }
+            Object obj = objectOptional.get();
+            String password = null;
+            if (obj instanceof CredentialsWithoutNullabilityAnnotation) {
+                password = ((CredentialsWithoutNullabilityAnnotation)obj).password
+            } else if (obj instanceof CredentialsWithNullable) {
+                password = ((CredentialsWithNullable)obj).password
+            } else if (obj instanceof CredentialsWithNonNull) {
+                password = ((CredentialsWithNonNull)obj).password
+            }
+            password != null ? Optional.of(Map.of("password", password)) : Optional.<Map>empty();
+        }
+    }
+
+    @Introspected
+    static class CredentialsWithoutNullabilityAnnotation {
+
+        @NotBlank
+        @Email
+        private final String username;
+
+        @NotBlank
+        private final String password;
+
+        CredentialsWithoutNullabilityAnnotation(String username, String password) {
+            this.username = username
+            this.password = password
+        }
+
+        String getUsername() {
+            username
+        }
+
+        String getPassword() {
+            password
+        }
+    }
+
+    @Introspected
+    static class CredentialsWithNullable {
+
+        @NotBlank
+        @Email
+        @Nullable
+        private final String username
+
+        @NotBlank
+        @Nullable
+        private final String password
+
+        CredentialsWithNullable(@Nullable String username, @Nullable String password) {
+            this.username = username
+            this.password = password
+        }
+
+        @Nullable
+        String getUsername() {
+            username
+        }
+
+        @Nullable
+        String getPassword() {
+            password
+        }
+    }
+
+    @Introspected
+    static class CredentialsWithNonNull {
+        @NotBlank
+        @Email
+        @NonNull
+        private final String username
+
+        @NotBlank
+        @NonNull
+        private final String password
+
+        CredentialsWithNonNull(@NonNull String username, @NonNull String password) {
+            this.username = username
+            this.password = password
+        }
+
+        @NonNull
+        String getUsername() {
+            username
+        }
+
+        @NonNull
+        String getPassword() {
+            password
+        }
+    }
+}

--- a/servlet-core/src/main/java/io/micronaut/servlet/http/ParsedBodyHolder.java
+++ b/servlet-core/src/main/java/io/micronaut/servlet/http/ParsedBodyHolder.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2017-2023 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.servlet.http;
+
+/**
+ * Interface to allow setting of parsed body on a request.
+ * When we parse the body of a request using ServletBodyBinder we read the body via the inputStream.
+ * Further requests to getBody (for example in an OnError handler) will then return an empty object as the stream is exhausted.
+ * This allows us to effectively cache the body, so we get the same object in the later handler.
+ *
+ * @param <B> The type of the body
+ */
+public interface ParsedBodyHolder<B> {
+
+    /**
+     * Set the parsed body.
+     * @param body the parsed body
+     */
+    void setParsedBody(B body);
+}

--- a/servlet-core/src/main/java/io/micronaut/servlet/http/ServletBodyBinder.java
+++ b/servlet-core/src/main/java/io/micronaut/servlet/http/ServletBodyBinder.java
@@ -174,6 +174,9 @@ public class ServletBodyBinder<T> implements AnnotatedRequestArgumentBinder<Body
                     } else {
                         content = codec.decode(argument, inputStream);
                     }
+                    if (content != null && servletHttpRequest instanceof ParsedBodyHolder parsedBody) {
+                        parsedBody.setParsedBody(content);
+                    }
                     return () -> Optional.of(content);
                 } catch (CodecException | IOException e) {
                     throw new CodecException("Unable to decode request body: " + e.getMessage(), e);

--- a/test-suite-http-server-tck-jetty/src/test/java/io/micronaut/http/server/tck/jetty/tests/JettyHttpServerTestSuite.java
+++ b/test-suite-http-server-tck-jetty/src/test/java/io/micronaut/http/server/tck/jetty/tests/JettyHttpServerTestSuite.java
@@ -15,7 +15,6 @@ import org.junit.platform.suite.api.SuiteDisplayName;
     "io.micronaut.http.server.tck.tests.staticresources.StaticResourceTest", // Graal fails to see /assets from the TCK as a resource https://ge.micronaut.io/s/ufuhtbe5sgmxi
     "io.micronaut.http.server.tck.tests.filter.ClientResponseFilterTest", // responseFilterThrowableParameter fails under Graal https://ge.micronaut.io/s/ufuhtbe5sgmxi
     "io.micronaut.http.server.tck.tests.codec.JsonCodecAdditionalTypeTest", // remove once this pr is merged https://github.com/micronaut-projects/micronaut-core/pull/9308/files
-    "io.micronaut.http.server.tck.tests.constraintshandler.ControllerConstraintHandlerTest", // Bug accessing request body in @OnError
 })
 public class JettyHttpServerTestSuite {
 }

--- a/test-suite-http-server-tck-tomcat/src/test/java/io/micronaut/http/server/tck/tomcat/tests/TomcatHttpServerTestSuite.java
+++ b/test-suite-http-server-tck-tomcat/src/test/java/io/micronaut/http/server/tck/tomcat/tests/TomcatHttpServerTestSuite.java
@@ -12,7 +12,6 @@ import org.junit.platform.suite.api.SuiteDisplayName;
     "io.micronaut.http.server.tck.tests.staticresources.StaticResourceTest", // Graal fails to see /assets from the TCK as a resource https://ge.micronaut.io/s/ufuhtbe5sgmxi
     "io.micronaut.http.server.tck.tests.filter.ClientResponseFilterTest", // responseFilterThrowableParameter fails under Graal https://ge.micronaut.io/s/ufuhtbe5sgmxi
     "io.micronaut.http.server.tck.tests.codec.JsonCodecAdditionalTypeTest", // remove once this pr is merged https://github.com/micronaut-projects/micronaut-core/pull/9308/files
-    "io.micronaut.http.server.tck.tests.constraintshandler.ControllerConstraintHandlerTest", // Bug accessing request body in @OnError
 })
 public class TomcatHttpServerTestSuite {
 }

--- a/test-suite-http-server-tck-undertow/src/test/java/io/micronaut/http/server/tck/undertow/tests/UndertowHttpServerTestSuite.java
+++ b/test-suite-http-server-tck-undertow/src/test/java/io/micronaut/http/server/tck/undertow/tests/UndertowHttpServerTestSuite.java
@@ -13,7 +13,6 @@ import org.junit.platform.suite.api.SuiteDisplayName;
     "io.micronaut.http.server.tck.tests.staticresources.StaticResourceTest", // Graal fails to see /assets from the TCK as a resource https://ge.micronaut.io/s/ufuhtbe5sgmxi
     "io.micronaut.http.server.tck.tests.filter.ClientResponseFilterTest", // responseFilterThrowableParameter fails under Graal https://ge.micronaut.io/s/ufuhtbe5sgmxi
     "io.micronaut.http.server.tck.tests.codec.JsonCodecAdditionalTypeTest", // remove once this pr is merged https://github.com/micronaut-projects/micronaut-core/pull/9308/files
-    "io.micronaut.http.server.tck.tests.constraintshandler.ControllerConstraintHandlerTest", // Bug accessing request body in @OnError
 })
 public class UndertowHttpServerTestSuite {
 }


### PR DESCRIPTION
When we run the ControllerConstraintHandlerTest the body is read twice. Once from the BodyBinder via the request inputstream and then again from the On Error handler.

The issue is that without changes, the second read gets nothing as the inputstream is exhausted. And we cannot cache the stream internally, as it is expected that the body is of the same type as created by the binder.

This fix introduces an interface so that the binder can effectively cache the body in the request. This cached body is then returned on the subsequent calls to getBody()