### PR TITLE
bug: Reactive Stream error handling is incorrect

### DIFF
--- a/http-server-jetty/src/test/groovy/io/micronaut/servlet/jetty/StreamErrorSpec.groovy
+++ b/http-server-jetty/src/test/groovy/io/micronaut/servlet/jetty/StreamErrorSpec.groovy
@@ -1,0 +1,65 @@
+package io.micronaut.servlet.jetty
+
+import io.micronaut.context.annotation.Property
+import io.micronaut.context.annotation.Requires
+import io.micronaut.http.HttpHeaders
+import io.micronaut.http.HttpRequest
+import io.micronaut.http.HttpStatus
+import io.micronaut.http.MediaType
+import io.micronaut.http.annotation.Controller
+import io.micronaut.http.annotation.Get
+import io.micronaut.http.client.HttpClient
+import io.micronaut.http.client.annotation.Client
+import io.micronaut.http.client.exceptions.HttpClientResponseException
+import io.micronaut.http.exceptions.HttpStatusException
+import io.micronaut.test.extensions.spock.annotation.MicronautTest
+import jakarta.inject.Inject
+import org.reactivestreams.Publisher
+import reactor.core.publisher.Flux
+import spock.lang.Specification
+
+@MicronautTest
+@Property(name = "spec.name", value = SPEC_NAME)
+class StreamErrorSpec extends Specification {
+
+    static final String SPEC_NAME = "StreamErrorSpec"
+
+    @Inject
+    @Client("/")
+    HttpClient client;
+
+    void "status error as first item"() {
+        when:
+        def response = client.toBlocking().exchange(HttpRequest.GET("/stream-error/status-error-as-first-item"), String)
+
+        then:
+        def e = thrown(HttpClientResponseException)
+        e.response.status == HttpStatus.NOT_FOUND
+        e.response.body() == "foo"
+    }
+
+    void "immediate status error"() {
+        when:
+        def response = client.toBlocking().exchange(HttpRequest.GET("/stream-error/status-error-immediate"), String)
+
+        then:
+        def e = thrown(HttpClientResponseException)
+        e.response.status == HttpStatus.NOT_FOUND
+        e.response.body() == "foo"
+    }
+
+    @Controller("/stream-error")
+    @Requires(property = "spec.name", value = SPEC_NAME)
+    static class StreamController {
+
+        @Get(uri = "/status-error-as-first-item")
+        Publisher<String> statusErrorAsFirstItem() {
+            return Flux.error(new HttpStatusException(HttpStatus.NOT_FOUND, (Object) "foo"));
+        }
+
+        @Get(uri = "/status-error-immediate")
+        Publisher<String> statusErrorImmediate() {
+            throw new HttpStatusException(HttpStatus.NOT_FOUND, (Object) "foo");
+        }
+    }
+}


### PR DESCRIPTION
In https://github.com/micronaut-projects/micronaut-servlet/pull/481 a new TCK test added for Micronaut 4.0.0 fails

It also fails in 3.3.x (for Micronaut 3.9.x) with a read-timeout exception.

I suspect that somewhere in https://github.com/micronaut-projects/micronaut-servlet/blob/72233979938ea2053c427111f58ed4100de052dd/servlet-engine/src/main/java/io/micronaut/servlet/engine/DefaultServletHttpResponse.java#L91

We are losing track of the error