### PR TITLE
Add binary-configuration to servlet-core

### DIFF
--- a/http-server-jetty/src/test/groovy/io/micronaut/servlet/jetty/JettyBinaryContentConfigurationSpec.groovy
+++ b/http-server-jetty/src/test/groovy/io/micronaut/servlet/jetty/JettyBinaryContentConfigurationSpec.groovy
@@ -1,0 +1,62 @@
+package io.micronaut.servlet.jetty
+
+import io.micronaut.context.BeanContext
+import io.micronaut.servlet.http.BinaryContentConfiguration
+import io.micronaut.test.extensions.spock.annotation.MicronautTest
+import jakarta.inject.Inject
+import spock.lang.Specification
+
+@MicronautTest
+class JettyBinaryContentConfigurationSpec extends Specification {
+
+    @Inject
+    BeanContext beanContext
+
+    void "binary content configuration is available"() {
+        expect:
+        beanContext.findBean(BinaryContentConfiguration).present
+    }
+
+    void "#contentType is detected as binary"() {
+        given:
+        def binaryContentConfiguration = beanContext.getBean(BinaryContentConfiguration)
+
+        expect:
+        binaryContentConfiguration.isBinary(contentType)
+
+        where:
+        contentType << [
+                "application/octet-stream",
+                "image/jpeg",
+                "image/png",
+                "image/gif",
+                "application/zip"
+        ]
+    }
+
+    void "#contentType is not detected as binary"() {
+        given:
+        def binaryContentConfiguration = beanContext.getBean(BinaryContentConfiguration)
+
+        expect:
+        !binaryContentConfiguration.isBinary(contentType)
+
+        where:
+        contentType << [
+                "text/plain",
+                "text/html",
+                "application/json",
+                "application/xml",
+                "application/x-www-form-urlencoded"
+        ]
+    }
+
+    void "configuration is modifiable"() {
+        given:
+        def binaryContentConfiguration = beanContext.getBean(BinaryContentConfiguration)
+        binaryContentConfiguration.addBinaryContentType("application/foobar")
+
+        expect:
+        binaryContentConfiguration.isBinary("application/foobar")
+    }
+}

--- a/servlet-core/src/main/java/io/micronaut/servlet/http/BinaryContentConfiguration.java
+++ b/servlet-core/src/main/java/io/micronaut/servlet/http/BinaryContentConfiguration.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright 2017-2023 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.servlet.http;
+
+import io.micronaut.core.annotation.Internal;
+import jakarta.inject.Singleton;
+
+import java.util.HashSet;
+import java.util.Set;
+
+/**
+ * Bean to define whether the content-type represents binary data.
+ * This is used in the function modules (aws, azure) to determine whether to base64 encode the response.
+ *
+ * @author Tim Yates
+ * @since 4.0.0
+ */
+@Internal
+@Singleton
+public final class BinaryContentConfiguration {
+
+    private final Set<String> binaryContentTypes = new HashSet<>();
+
+    public BinaryContentConfiguration() {
+        binaryContentTypes.addAll(Set.of(
+                "application/octet-stream",
+                "image/jpeg",
+                "image/png",
+                "image/gif",
+                "application/zip"
+        ));
+    }
+
+    /**
+     * Add a content type to the list of binary content types.
+     *
+     * @param contentType The content type to add
+     */
+    public void addBinaryContentType(String contentType) {
+        binaryContentTypes.add(contentType);
+    }
+
+    /**
+     * @param contentType The content type
+     * @return True if the content type is considered binary
+     */
+    public boolean isBinary(String contentType) {
+        if (contentType != null) {
+            int semidx = contentType.indexOf(';');
+            if (semidx > -1) {
+                return binaryContentTypes.contains(contentType.substring(0, semidx).trim());
+            } else {
+                return binaryContentTypes.contains(contentType.trim());
+            }
+        }
+        return false;
+    }
+}

--- a/servlet-core/src/test/groovy/io/micronaut/servlet/http/BinaryContentConfigurationSpec.groovy
+++ b/servlet-core/src/test/groovy/io/micronaut/servlet/http/BinaryContentConfigurationSpec.groovy
@@ -1,0 +1,47 @@
+package io.micronaut.servlet.http
+
+import spock.lang.Specification
+import spock.lang.Subject
+
+class BinaryContentConfigurationSpec extends Specification {
+
+    @Subject
+    BinaryContentConfiguration binaryContentConfiguration = new BinaryContentConfiguration()
+
+    void "#contentType is detected as binary"() {
+        expect:
+        binaryContentConfiguration.isBinary(contentType)
+
+        where:
+        contentType << [
+                "application/octet-stream",
+                "image/jpeg",
+                "image/png",
+                "image/gif",
+                "application/zip"
+        ]
+    }
+
+    void "#contentType is not detected as binary"() {
+        expect:
+        !binaryContentConfiguration.isBinary(contentType)
+
+        where:
+        contentType << [
+                "text/plain",
+                "text/html",
+                "application/json",
+                "application/xml",
+                "application/x-www-form-urlencoded"
+        ]
+    }
+
+    void "configuration is modifiable"() {
+        given:
+        BinaryContentConfiguration config = new BinaryContentConfiguration()
+        config.addBinaryContentType("application/foobar")
+
+        expect:
+        config.isBinary("application/foobar")
+    }
+}


### PR DESCRIPTION
This class was used in both AWS and Azure, so we have pulled it up into servlet-core