### PR TITLE
Fix Jetty with multiple static resources

### DIFF
--- a/http-server-jetty/src/main/java/io/micronaut/servlet/jetty/JettyFactory.java
+++ b/http-server-jetty/src/main/java/io/micronaut/servlet/jetty/JettyFactory.java
@@ -50,6 +50,8 @@ import java.io.IOException;
 import java.util.List;
 import java.util.stream.Stream;
 
+import static io.micronaut.core.util.StringUtils.isEmpty;
+
 /**
  * Factory for the Jetty server.
  *
@@ -238,12 +240,16 @@ public class JettyFactory extends ServletServerFactory {
 
         ResourceHandler resourceHandler = new ResourceHandler();
         resourceHandler.setBaseResource(mappedResourceCollection);
+        resourceHandler.setDirAllowed(false);
         resourceHandler.setDirectoriesListed(false);
-        resourceHandler.setCacheControl("private, max-age=60");
+        if (!isEmpty(config.getCacheControl())) {
+            resourceHandler.setCacheControl(config.getCacheControl());
+        }
 
         ContextHandler contextHandler = new ContextHandler(path + "/*");
         contextHandler.setContextPath("/");
         contextHandler.setHandler(resourceHandler);
+        contextHandler.setDisplayName("Static Resources " + mapping);
 
         return contextHandler;
     }

--- a/http-server-jetty/src/test/groovy/io/micronaut/servlet/jetty/JettyStaticResourceResolutionSpec.groovy
+++ b/http-server-jetty/src/test/groovy/io/micronaut/servlet/jetty/JettyStaticResourceResolutionSpec.groovy
@@ -80,7 +80,7 @@ class JettyStaticResourceResolutionSpec extends Specification implements TestPro
         response.header(CONTENT_TYPE) == "text/html"
         Integer.parseInt(response.header(CONTENT_LENGTH)) > 0
         response.headers.contains(CACHE_CONTROL)
-        response.header(CACHE_CONTROL) == "private, max-age=60"
+        response.header(CACHE_CONTROL) == "private,max-age=60"
         response.body() == "<html><head></head><body>HTML Page from static file</body></html>"
     }
 
@@ -98,7 +98,7 @@ class JettyStaticResourceResolutionSpec extends Specification implements TestPro
         response.header(CONTENT_TYPE) == "text/html"
         Integer.parseInt(response.header(CONTENT_LENGTH)) > 0
         response.headers.contains(CACHE_CONTROL)
-        response.header(CACHE_CONTROL) == "private, max-age=60"
+        response.header(CACHE_CONTROL) == "private,max-age=60"
 
         response.body() == "<html><head></head><body>HTML Page from resources</body></html>"
     }
@@ -117,7 +117,7 @@ class JettyStaticResourceResolutionSpec extends Specification implements TestPro
         response.header(CONTENT_TYPE) == "text/html"
         Integer.parseInt(response.header(CONTENT_LENGTH)) > 0
         response.headers.contains(CACHE_CONTROL)
-        response.header(CACHE_CONTROL) == "private, max-age=60"
+        response.header(CACHE_CONTROL) == "private,max-age=60"
 
         response.body() == "<html><head></head><body>HTML Page from resources</body></html>"
     }
@@ -220,7 +220,9 @@ class JettyStaticResourceResolutionSpec extends Specification implements TestPro
         given:
         EmbeddedServer embeddedServer = ApplicationContext.run(EmbeddedServer, [
                 'micronaut.router.static-resources.default.paths': ['classpath:public'],
-                'micronaut.router.static-resources.default.mapping': '/static/**'])
+                'micronaut.router.static-resources.default.mapping': '/static/**',
+                'micronaut.router.static-resources.default.cache-control': '', // clear the cache control header
+        ])
         HttpClient rxClient = embeddedServer.applicationContext.createBean(HttpClient, embeddedServer.getURL())
 
 
@@ -235,8 +237,10 @@ class JettyStaticResourceResolutionSpec extends Specification implements TestPro
         response.code() == HttpStatus.OK.code
         response.header(CONTENT_TYPE) == "text/html"
         Integer.parseInt(response.header(CONTENT_LENGTH)) > 0
-        response.headers.contains(CACHE_CONTROL)
         response.body() == "<html><head></head><body>HTML Page from resources/foo</body></html>"
+
+        and: 'the cache control header is not set'
+        !response.headers.contains(CACHE_CONTROL)
 
         cleanup:
         embeddedServer.stop()

--- a/http-server-jetty/src/test/groovy/io/micronaut/servlet/jetty/JettyStaticResourceResolutionSpec.groovy
+++ b/http-server-jetty/src/test/groovy/io/micronaut/servlet/jetty/JettyStaticResourceResolutionSpec.groovy
@@ -17,7 +17,6 @@ import io.micronaut.test.support.TestPropertyProvider
 import io.micronaut.web.router.resource.StaticResourceConfiguration
 import jakarta.inject.Inject
 import spock.lang.Issue
-import spock.lang.PendingFeature
 import spock.lang.Specification
 
 import java.nio.file.Files
@@ -81,7 +80,7 @@ class JettyStaticResourceResolutionSpec extends Specification implements TestPro
         response.header(CONTENT_TYPE) == "text/html"
         Integer.parseInt(response.header(CONTENT_LENGTH)) > 0
         response.headers.contains(CACHE_CONTROL)
-        response.header(CACHE_CONTROL) == "max-age=3600,public"
+        response.header(CACHE_CONTROL) == "private, max-age=60"
         response.body() == "<html><head></head><body>HTML Page from static file</body></html>"
     }
 
@@ -99,7 +98,7 @@ class JettyStaticResourceResolutionSpec extends Specification implements TestPro
         response.header(CONTENT_TYPE) == "text/html"
         Integer.parseInt(response.header(CONTENT_LENGTH)) > 0
         response.headers.contains(CACHE_CONTROL)
-        response.header(CACHE_CONTROL) == "max-age=3600,public"
+        response.header(CACHE_CONTROL) == "private, max-age=60"
 
         response.body() == "<html><head></head><body>HTML Page from resources</body></html>"
     }
@@ -118,7 +117,7 @@ class JettyStaticResourceResolutionSpec extends Specification implements TestPro
         response.header(CONTENT_TYPE) == "text/html"
         Integer.parseInt(response.header(CONTENT_LENGTH)) > 0
         response.headers.contains(CACHE_CONTROL)
-        response.header(CACHE_CONTROL) == "max-age=3600,public"
+        response.header(CACHE_CONTROL) == "private, max-age=60"
 
         response.body() == "<html><head></head><body>HTML Page from resources</body></html>"
     }
@@ -142,7 +141,7 @@ class JettyStaticResourceResolutionSpec extends Specification implements TestPro
         response.code() == HttpStatus.OK.code
         response.header(CONTENT_TYPE) == "text/html"
         Integer.parseInt(response.header(CONTENT_LENGTH)) > 0
-        !response.headers.contains(CACHE_CONTROL)
+        response.headers.contains(CACHE_CONTROL)
 
         response.body() == "<html><head></head><body>HTML Page from resources</body></html>"
 
@@ -175,7 +174,7 @@ class JettyStaticResourceResolutionSpec extends Specification implements TestPro
         response.code() == HttpStatus.OK.code
         response.header(CONTENT_TYPE) == "text/html"
         Integer.parseInt(response.header(CONTENT_LENGTH)) > 0
-        !response.headers.contains(CACHE_CONTROL)
+        response.headers.contains(CACHE_CONTROL)
 
         response.body() == "<html><head></head><body>HTML Page from resources</body></html>"
 
@@ -209,7 +208,7 @@ class JettyStaticResourceResolutionSpec extends Specification implements TestPro
         response.code() == HttpStatus.OK.code
         response.header(CONTENT_TYPE) == "text/html"
         Integer.parseInt(response.header(CONTENT_LENGTH)) > 0
-        !response.headers.contains(CACHE_CONTROL)
+        response.headers.contains(CACHE_CONTROL)
         response.body() == "<html><head></head><body>HTML Page from resources</body></html>"
 
         cleanup:
@@ -236,7 +235,7 @@ class JettyStaticResourceResolutionSpec extends Specification implements TestPro
         response.code() == HttpStatus.OK.code
         response.header(CONTENT_TYPE) == "text/html"
         Integer.parseInt(response.header(CONTENT_LENGTH)) > 0
-        !response.headers.contains(CACHE_CONTROL)
+        response.headers.contains(CACHE_CONTROL)
         response.body() == "<html><head></head><body>HTML Page from resources/foo</body></html>"
 
         cleanup:
@@ -297,7 +296,6 @@ class JettyStaticResourceResolutionSpec extends Specification implements TestPro
     }
 
     @Issue("https://github.com/micronaut-projects/micronaut-servlet/issues/251")
-    @PendingFeature
     void "multiple index.html files causes issues with the static resource handling"() {
         given:
         EmbeddedServer embeddedServer = ApplicationContext.run(EmbeddedServer, [

--- a/http-server-jetty/src/test/resources/logback.xml
+++ b/http-server-jetty/src/test/resources/logback.xml
@@ -13,5 +13,6 @@
     </root>
 <!--    <logger name="io.micronaut.http.client" level="trace" />-->
 <!--    <logger name="io.micronaut.servlet.http" level="trace" />-->
+<!--    <logger name="io.micronaut.servlet.jetty" level="trace" />-->
 <!--    <logger name="org.eclipse.jetty.server" level="trace" />-->
 </configuration>

--- a/http-server-jetty/src/test/resources/nest-test/nested/index.html
+++ b/http-server-jetty/src/test/resources/nest-test/nested/index.html
@@ -1,0 +1,5 @@
+<html>
+<body>
+<h1>Nest</h1>
+</body>
+</html>

--- a/http-server-jetty/src/test/resources/nest-test/something.txt
+++ b/http-server-jetty/src/test/resources/nest-test/something.txt
@@ -1,0 +1,1 @@
+Something

--- a/http-server-tomcat/src/test/groovy/io/micronaut/servlet/tomcat/TomcatStaticResourceResolutionSpec.groovy
+++ b/http-server-tomcat/src/test/groovy/io/micronaut/servlet/tomcat/TomcatStaticResourceResolutionSpec.groovy
@@ -15,6 +15,8 @@ import io.micronaut.test.extensions.spock.annotation.MicronautTest
 import io.micronaut.test.support.TestPropertyProvider
 import io.micronaut.web.router.resource.StaticResourceConfiguration
 import jakarta.inject.Inject
+import spock.lang.Issue
+import spock.lang.PendingFeature
 import spock.lang.Specification
 
 import java.nio.file.Paths
@@ -250,5 +252,80 @@ class TomcatStaticResourceResolutionSpec extends Specification implements TestPr
         cleanup:
         embeddedServer?.stop()
         embeddedServer?.close()
+    }
+
+    @Issue("https://github.com/micronaut-projects/micronaut-servlet/issues/251")
+    void "test resources with mapping names that are prefixes of one another can resolve index.html and a resource"() {
+        given:
+        EmbeddedServer embeddedServer = ApplicationContext.run(EmbeddedServer, [
+                'micronaut.router.static-resources.nest.paths': ['classpath:nest-test/nested'],
+                'micronaut.router.static-resources.nest.mapping': '/nest/**', // This mapping
+                'micronaut.router.static-resources.nest-test.paths': ['classpath:nest-test'],
+                'micronaut.router.static-resources.nest-test.mapping': '/nest-test/**', // is a prefix of this mapping (same with swagger and swagger-ui)
+        ])
+        def client = embeddedServer.applicationContext.createBean(HttpClient, embeddedServer.getURL()).toBlocking()
+
+        when:
+        def nestResponse = client.exchange(HttpRequest.GET("/nest"), String)
+        def nestText = this.class.classLoader.getResource("nest-test/nested/index.html").text
+
+        def nestTestResponse = client.exchange(HttpRequest.GET("/nest-test/something.txt"), String)
+        def nestTestText = this.class.classLoader.getResource("nest-test/something.txt").text
+
+        then:
+        with(nestResponse) {
+            code() == HttpStatus.OK.code
+            header(CONTENT_TYPE) == "text/html"
+            Integer.parseInt(header(CONTENT_LENGTH)) > 0
+            body() == nestText
+        }
+
+        with(nestTestResponse) {
+            code() == HttpStatus.OK.code
+            Integer.parseInt(header(CONTENT_LENGTH)) > 0
+            body() == nestTestText
+        }
+
+        cleanup:
+        embeddedServer.stop()
+        embeddedServer.close()
+    }
+
+    @Issue("https://github.com/micronaut-projects/micronaut-servlet/issues/251")
+    void "multiple index.html files causes issues with the static resource handling"() {
+        given:
+        EmbeddedServer embeddedServer = ApplicationContext.run(EmbeddedServer, [
+                'micronaut.router.static-resources.nest.paths': ['classpath:nest-test/nested'],
+                'micronaut.router.static-resources.nest.mapping': '/nest/**',
+                'micronaut.router.static-resources.public.paths': ['classpath:public'],
+                'micronaut.router.static-resources.public.mapping': '/public/**',
+        ])
+        def client = embeddedServer.applicationContext.createBean(HttpClient, embeddedServer.getURL()).toBlocking()
+
+        when:
+        def nestResponse = client.exchange(HttpRequest.GET("/nest"), String)
+        def nestText = this.class.classLoader.getResource("nest-test/nested/index.html").text
+
+        def publicResponse = client.exchange(HttpRequest.GET("/public/index.html"), String)
+        def publicText = this.class.classLoader.getResource("public/index.html").text
+
+        then:
+        with(nestResponse) {
+            code() == HttpStatus.OK.code
+            header(CONTENT_TYPE) == "text/html"
+            Integer.parseInt(header(CONTENT_LENGTH)) > 0
+            body() == nestText
+        }
+
+        with(publicResponse) {
+            code() == HttpStatus.OK.code
+            header(CONTENT_TYPE) == "text/html"
+            Integer.parseInt(header(CONTENT_LENGTH)) > 0
+            body() == publicText
+        }
+
+        cleanup:
+        embeddedServer.stop()
+        embeddedServer.close()
     }
 }

--- a/http-server-tomcat/src/test/resources/nest-test/nested/index.html
+++ b/http-server-tomcat/src/test/resources/nest-test/nested/index.html
@@ -1,0 +1,5 @@
+<html>
+<body>
+<h1>Nest</h1>
+</body>
+</html>

--- a/http-server-tomcat/src/test/resources/nest-test/something.txt
+++ b/http-server-tomcat/src/test/resources/nest-test/something.txt
@@ -1,0 +1,1 @@
+Something

--- a/http-server-undertow/src/test/groovy/io/micronaut/servlet/undertow/UndertowStaticResourceResolutionSpec.groovy
+++ b/http-server-undertow/src/test/groovy/io/micronaut/servlet/undertow/UndertowStaticResourceResolutionSpec.groovy
@@ -15,6 +15,8 @@ import io.micronaut.test.extensions.spock.annotation.MicronautTest
 import io.micronaut.test.support.TestPropertyProvider
 import io.micronaut.web.router.resource.StaticResourceConfiguration
 import jakarta.inject.Inject
+import spock.lang.Issue
+import spock.lang.PendingFeature
 import spock.lang.Specification
 
 import java.nio.file.Paths
@@ -248,5 +250,80 @@ class UndertowStaticResourceResolutionSpec extends Specification implements Test
         cleanup:
         embeddedServer?.stop()
         embeddedServer?.close()
+    }
+
+    @Issue("https://github.com/micronaut-projects/micronaut-servlet/issues/251")
+    void "test resources with mapping names that are prefixes of one another can resolve index.html and a resource"() {
+        given:
+        EmbeddedServer embeddedServer = ApplicationContext.run(EmbeddedServer, [
+                'micronaut.router.static-resources.nest.paths': ['classpath:nest-test/nested'],
+                'micronaut.router.static-resources.nest.mapping': '/nest/**', // This mapping
+                'micronaut.router.static-resources.nest-test.paths': ['classpath:nest-test'],
+                'micronaut.router.static-resources.nest-test.mapping': '/nest-test/**', // is a prefix of this mapping (same with swagger and swagger-ui)
+        ])
+        def client = embeddedServer.applicationContext.createBean(HttpClient, embeddedServer.getURL()).toBlocking()
+
+        when:
+        def nestResponse = client.exchange(HttpRequest.GET("/nest"), String)
+        def nestText = this.class.classLoader.getResource("nest-test/nested/index.html").text
+
+        def nestTestResponse = client.exchange(HttpRequest.GET("/nest-test/something.txt"), String)
+        def nestTestText = this.class.classLoader.getResource("nest-test/something.txt").text
+
+        then:
+        with(nestResponse) {
+            code() == HttpStatus.OK.code
+            header(CONTENT_TYPE) == "text/html"
+            Integer.parseInt(header(CONTENT_LENGTH)) > 0
+            body() == nestText
+        }
+
+        with(nestTestResponse) {
+            code() == HttpStatus.OK.code
+            Integer.parseInt(header(CONTENT_LENGTH)) > 0
+            body() == nestTestText
+        }
+
+        cleanup:
+        embeddedServer.stop()
+        embeddedServer.close()
+    }
+
+    @Issue("https://github.com/micronaut-projects/micronaut-servlet/issues/251")
+    void "multiple index.html files causes issues with the static resource handling"() {
+        given:
+        EmbeddedServer embeddedServer = ApplicationContext.run(EmbeddedServer, [
+                'micronaut.router.static-resources.nest.paths': ['classpath:nest-test/nested'],
+                'micronaut.router.static-resources.nest.mapping': '/nest/**',
+                'micronaut.router.static-resources.public.paths': ['classpath:public'],
+                'micronaut.router.static-resources.public.mapping': '/public/**',
+        ])
+        def client = embeddedServer.applicationContext.createBean(HttpClient, embeddedServer.getURL()).toBlocking()
+
+        when:
+        def nestResponse = client.exchange(HttpRequest.GET("/nest"), String)
+        def nestText = this.class.classLoader.getResource("nest-test/nested/index.html").text
+
+        def publicResponse = client.exchange(HttpRequest.GET("/public/index.html"), String)
+        def publicText = this.class.classLoader.getResource("public/index.html").text
+
+        then:
+        with(nestResponse) {
+            code() == HttpStatus.OK.code
+            header(CONTENT_TYPE) == "text/html"
+            Integer.parseInt(header(CONTENT_LENGTH)) > 0
+            body() == nestText
+        }
+
+        with(publicResponse) {
+            code() == HttpStatus.OK.code
+            header(CONTENT_TYPE) == "text/html"
+            Integer.parseInt(header(CONTENT_LENGTH)) > 0
+            body() == publicText
+        }
+
+        cleanup:
+        embeddedServer.stop()
+        embeddedServer.close()
     }
 }

--- a/http-server-undertow/src/test/resources/nest-test/nested/index.html
+++ b/http-server-undertow/src/test/resources/nest-test/nested/index.html
@@ -1,0 +1,5 @@
+<html>
+<body>
+<h1>Nest</h1>
+</body>
+</html>

--- a/http-server-undertow/src/test/resources/nest-test/something.txt
+++ b/http-server-undertow/src/test/resources/nest-test/something.txt
@@ -1,0 +1,1 @@
+Something

--- a/servlet-engine/src/main/java/io/micronaut/servlet/engine/server/ServletStaticResourceConfiguration.java
+++ b/servlet-engine/src/main/java/io/micronaut/servlet/engine/server/ServletStaticResourceConfiguration.java
@@ -57,6 +57,7 @@ public interface ServletStaticResourceConfiguration extends Toggleable {
      * For Jetty based servers, allow configuring the cache control header for static resource mappings (defaults to {@value #DEFAULT_CACHE_CONTROL_HEADER}).
      *
      * @return The cache control header
+     * @since 4.0.4
      */
     @Bindable(defaultValue = DEFAULT_CACHE_CONTROL_HEADER)
     String getCacheControl();

--- a/servlet-engine/src/main/java/io/micronaut/servlet/engine/server/ServletStaticResourceConfiguration.java
+++ b/servlet-engine/src/main/java/io/micronaut/servlet/engine/server/ServletStaticResourceConfiguration.java
@@ -36,6 +36,7 @@ public interface ServletStaticResourceConfiguration extends Toggleable {
 
     String CLASSPATH_PREFIX = "classpath:";
     String FILE_PREFIX = "file:";
+    String DEFAULT_CACHE_CONTROL_HEADER = "private,max-age=60";
 
     /**
      * @return The mapping
@@ -51,4 +52,12 @@ public interface ServletStaticResourceConfiguration extends Toggleable {
     @Override
     @Bindable(defaultValue = StringUtils.TRUE)
     boolean isEnabled();
+
+    /**
+     * For Jetty based servers, allow configuring the cache control header for static resource mappings (defaults to {@value #DEFAULT_CACHE_CONTROL_HEADER}).
+     *
+     * @return The cache control header
+     */
+    @Bindable(defaultValue = DEFAULT_CACHE_CONTROL_HEADER)
+    String getCacheControl();
 }


### PR DESCRIPTION
Static resources with Jetty were handled by adding a DefaultServlet and adding all the static resources (files and classpaths) into a large pool.

This had 2 issues.

1. There was a bug in the way we handled paths which meant that using having paths of `swagger` and `swagger-ui` for example would mean a request to `swagger-ui/index.html` would look for a resource named `swagger/-ui/index.html`
2. Having all the resources in a single pool meant that if we had 2 static paths containing a file of the same name, it was effectively random which file would be returned.

The change here is (in Jetty) to use a ResourceHandler for each static-mapping, with just the resources specified for that mapping.
I also added a configuration item to allow configuration of cache control response header when using Jetty. This was done as the header changed from when it was using a DefaultServlet (for reasons I don't fully understand)

I believe this PR:

Fixes #240
Fixes #251