### PR TITLE
Handle streaming response errors

### DIFF
--- a/http-server-jetty/src/test/groovy/io/micronaut/servlet/jetty/JettyErrorSpec.groovy
+++ b/http-server-jetty/src/test/groovy/io/micronaut/servlet/jetty/JettyErrorSpec.groovy
@@ -12,8 +12,10 @@ import io.micronaut.http.annotation.Produces
 import io.micronaut.http.annotation.Status
 import io.micronaut.http.client.HttpClient
 import io.micronaut.http.client.annotation.Client
+import io.micronaut.http.client.exceptions.HttpClientResponseException
 import io.micronaut.test.extensions.spock.annotation.MicronautTest
 import jakarta.inject.Inject
+import reactor.core.publisher.Flux
 import spock.lang.Specification
 
 @MicronautTest
@@ -35,6 +37,26 @@ class JettyErrorSpec extends Specification {
         result.header(HttpHeaders.CONTENT_TYPE).startsWith(MediaType.TEXT_PLAIN)
     }
 
+    void "error that occurs with streaming response results in client receiving an error"() {
+        when:
+        client.toBlocking().exchange("/errors/stream-immediate", String)
+
+        then:
+        HttpClientResponseException ex = thrown(HttpClientResponseException)
+        ex.status == HttpStatus.INTERNAL_SERVER_ERROR
+        ex.response.body.orElseThrow() == "Internal Server Error: Immediate error"
+    }
+
+    void "error that occurs with streaming response after data sent results in client receiving incomplete data"() {
+        when:
+        client.toBlocking().exchange("/errors/stream-delayed", Integer[].class)
+
+        then:
+        HttpClientResponseException ex = thrown(HttpClientResponseException)
+        ex.status == HttpStatus.OK
+        ex.message.contains("Unexpected end-of-input")
+    }
+
     @Requires(property = "spec.name", value = "JettyErrorSpec")
     @Controller("/errors")
     static class ErrorController {
@@ -42,7 +64,22 @@ class JettyErrorSpec extends Specification {
         @Get("/local")
         @Produces(MediaType.APPLICATION_PDF)
         String localHandler() {
-            throw new AnotherException("bad things");
+            throw new AnotherException("bad things")
+        }
+
+        @Get("/stream-immediate")
+        Flux<String> streamingImmediateError() {
+            return Flux.error(new IllegalStateException("Immediate error"))
+        }
+
+        @Get("/stream-delayed")
+        Flux<Integer> streamingDelayedError() {
+            return Flux.range(1, 5).map(data -> {
+                if (data == 3) {
+                    throw new IllegalStateException("Delayed error")
+                }
+                return data
+            })
         }
 
         @Error

--- a/http-server-jetty/src/test/groovy/io/micronaut/servlet/jetty/JettyErrorSpec.groovy
+++ b/http-server-jetty/src/test/groovy/io/micronaut/servlet/jetty/JettyErrorSpec.groovy
@@ -52,7 +52,7 @@ class JettyErrorSpec extends Specification {
         client.toBlocking().exchange("/errors/stream-delayed", Integer[].class)
 
         then:
-        HttpClientResponseException ex = thrown(HttpClientResponseException)
+        HttpClientResponseException ex = thrown()
         ex.status == HttpStatus.OK
         ex.message.contains("Unexpected end-of-input")
     }

--- a/http-server-jetty/src/test/groovy/io/micronaut/servlet/jetty/JettyErrorSpec.groovy
+++ b/http-server-jetty/src/test/groovy/io/micronaut/servlet/jetty/JettyErrorSpec.groovy
@@ -42,7 +42,7 @@ class JettyErrorSpec extends Specification {
         client.toBlocking().exchange("/errors/stream-immediate", String)
 
         then:
-        HttpClientResponseException ex = thrown(HttpClientResponseException)
+        HttpClientResponseException ex = thrown()
         ex.status == HttpStatus.INTERNAL_SERVER_ERROR
         ex.response.body.orElseThrow() == "Internal Server Error: Immediate error"
     }

--- a/http-server-tomcat/src/test/groovy/io/micronaut/servlet/tomcat/TomcatErrorSpec.groovy
+++ b/http-server-tomcat/src/test/groovy/io/micronaut/servlet/tomcat/TomcatErrorSpec.groovy
@@ -42,7 +42,7 @@ class TomcatErrorSpec extends Specification {
         client.toBlocking().exchange("/errors/stream-immediate", String)
 
         then:
-        HttpClientResponseException ex = thrown(HttpClientResponseException)
+        HttpClientResponseException ex = thrown()
         ex.status == HttpStatus.INTERNAL_SERVER_ERROR
         ex.response.body.orElseThrow() == "Internal Server Error: Immediate error"
     }

--- a/http-server-tomcat/src/test/groovy/io/micronaut/servlet/tomcat/TomcatErrorSpec.groovy
+++ b/http-server-tomcat/src/test/groovy/io/micronaut/servlet/tomcat/TomcatErrorSpec.groovy
@@ -52,7 +52,7 @@ class TomcatErrorSpec extends Specification {
         client.toBlocking().exchange("/errors/stream-delayed", Integer[].class)
 
         then:
-        HttpClientResponseException ex = thrown(HttpClientResponseException)
+        HttpClientResponseException ex = thrown()
         ex.status == HttpStatus.OK
         ex.message.contains("Unexpected end-of-input")
     }

--- a/http-server-tomcat/src/test/groovy/io/micronaut/servlet/tomcat/TomcatErrorSpec.groovy
+++ b/http-server-tomcat/src/test/groovy/io/micronaut/servlet/tomcat/TomcatErrorSpec.groovy
@@ -12,8 +12,10 @@ import io.micronaut.http.annotation.Produces
 import io.micronaut.http.annotation.Status
 import io.micronaut.http.client.HttpClient
 import io.micronaut.http.client.annotation.Client
+import io.micronaut.http.client.exceptions.HttpClientResponseException
 import io.micronaut.test.extensions.spock.annotation.MicronautTest
 import jakarta.inject.Inject
+import reactor.core.publisher.Flux
 import spock.lang.Specification
 
 @MicronautTest
@@ -35,6 +37,26 @@ class TomcatErrorSpec extends Specification {
         result.header(HttpHeaders.CONTENT_TYPE).startsWith(MediaType.TEXT_PLAIN)
     }
 
+    void "error that occurs with streaming response results in client receiving an error"() {
+        when:
+        client.toBlocking().exchange("/errors/stream-immediate", String)
+
+        then:
+        HttpClientResponseException ex = thrown(HttpClientResponseException)
+        ex.status == HttpStatus.INTERNAL_SERVER_ERROR
+        ex.response.body.orElseThrow() == "Internal Server Error: Immediate error"
+    }
+
+    void "error that occurs with streaming response after data sent results in client receiving incomplete data"() {
+        when:
+        client.toBlocking().exchange("/errors/stream-delayed", Integer[].class)
+
+        then:
+        HttpClientResponseException ex = thrown(HttpClientResponseException)
+        ex.status == HttpStatus.OK
+        ex.message.contains("Unexpected end-of-input")
+    }
+
     @Requires(property = "spec.name", value = "TomcatErrorSpec")
     @Controller("/errors")
     static class ErrorController {
@@ -42,7 +64,22 @@ class TomcatErrorSpec extends Specification {
         @Get("/local")
         @Produces(MediaType.APPLICATION_PDF)
         String localHandler() {
-            throw new AnotherException("bad things");
+            throw new AnotherException("bad things")
+        }
+
+        @Get("/stream-immediate")
+        Flux<String> streamingImmediateError() {
+            return Flux.error(new IllegalStateException("Immediate error"))
+        }
+
+        @Get("/stream-delayed")
+        Flux<Integer> streamingDelayedError() {
+            return Flux.range(1, 5).map(data -> {
+                if (data == 3) {
+                    throw new IllegalStateException("Delayed error")
+                }
+                return data
+            })
         }
 
         @Error

--- a/http-server-undertow/src/test/groovy/io/micronaut/servlet/undertow/UndertowErrorSpec.groovy
+++ b/http-server-undertow/src/test/groovy/io/micronaut/servlet/undertow/UndertowErrorSpec.groovy
@@ -52,7 +52,7 @@ class UndertowErrorSpec extends Specification {
         client.toBlocking().exchange("/errors/stream-delayed", Integer[].class)
 
         then:
-        HttpClientResponseException ex = thrown(HttpClientResponseException)
+        HttpClientResponseException ex = thrown()
         ex.status == HttpStatus.OK
         ex.message.contains("Unexpected end-of-input")
     }

--- a/http-server-undertow/src/test/groovy/io/micronaut/servlet/undertow/UndertowErrorSpec.groovy
+++ b/http-server-undertow/src/test/groovy/io/micronaut/servlet/undertow/UndertowErrorSpec.groovy
@@ -12,8 +12,10 @@ import io.micronaut.http.annotation.Produces
 import io.micronaut.http.annotation.Status
 import io.micronaut.http.client.HttpClient
 import io.micronaut.http.client.annotation.Client
+import io.micronaut.http.client.exceptions.HttpClientResponseException
 import io.micronaut.test.extensions.spock.annotation.MicronautTest
 import jakarta.inject.Inject
+import reactor.core.publisher.Flux
 import spock.lang.Specification
 
 @MicronautTest
@@ -35,6 +37,26 @@ class UndertowErrorSpec extends Specification {
         result.header(HttpHeaders.CONTENT_TYPE).startsWith(MediaType.TEXT_PLAIN)
     }
 
+    void "error that occurs with streaming response results in client receiving an error"() {
+        when:
+        client.toBlocking().exchange("/errors/stream-immediate", String)
+
+        then:
+        HttpClientResponseException ex = thrown(HttpClientResponseException)
+        ex.status == HttpStatus.INTERNAL_SERVER_ERROR
+        ex.response.body.orElseThrow() == "Internal Server Error: Immediate error"
+    }
+
+    void "error that occurs with streaming response after data sent results in client receiving incomplete data"() {
+        when:
+        client.toBlocking().exchange("/errors/stream-delayed", Integer[].class)
+
+        then:
+        HttpClientResponseException ex = thrown(HttpClientResponseException)
+        ex.status == HttpStatus.OK
+        ex.message.contains("Unexpected end-of-input")
+    }
+
     @Requires(property = "spec.name", value = "UndertowErrorSpec")
     @Controller("/errors")
     static class ErrorController {
@@ -42,7 +64,22 @@ class UndertowErrorSpec extends Specification {
         @Get("/local")
         @Produces(MediaType.APPLICATION_PDF)
         String localHandler() {
-            throw new AnotherException("bad things");
+            throw new AnotherException("bad things")
+        }
+
+        @Get("/stream-immediate")
+        Flux<String> streamingImmediateError() {
+            return Flux.error(new IllegalStateException("Immediate error"))
+        }
+
+        @Get("/stream-delayed")
+        Flux<Integer> streamingDelayedError() {
+            return Flux.range(1, 5).map(data -> {
+                if (data == 3) {
+                    throw new IllegalStateException("Delayed error")
+                }
+                return data
+            })
         }
 
         @Error

--- a/http-server-undertow/src/test/groovy/io/micronaut/servlet/undertow/UndertowErrorSpec.groovy
+++ b/http-server-undertow/src/test/groovy/io/micronaut/servlet/undertow/UndertowErrorSpec.groovy
@@ -42,7 +42,7 @@ class UndertowErrorSpec extends Specification {
         client.toBlocking().exchange("/errors/stream-immediate", String)
 
         then:
-        HttpClientResponseException ex = thrown(HttpClientResponseException)
+        HttpClientResponseException ex = thrown()
         ex.status == HttpStatus.INTERNAL_SERVER_ERROR
         ex.response.body.orElseThrow() == "Internal Server Error: Immediate error"
     }

--- a/servlet-core/src/main/java/io/micronaut/servlet/http/ServletHttpHandler.java
+++ b/servlet-core/src/main/java/io/micronaut/servlet/http/ServletHttpHandler.java
@@ -420,7 +420,9 @@ public abstract class ServletHttpHandler<REQ, RES> implements AutoCloseable, Lif
                 } else {
                     // stream case
                     if (exchange.getRequest().isAsyncSupported()) {
-                        Mono.from(servletResponse.stream(publisher)).subscribe(responsePublisherCallback);
+                        Mono.from(servletResponse.stream(publisher)).subscribe(responsePublisherCallback, throwable -> {
+                            responsePublisherCallback.accept(null);
+                        });
                         return;
                     } else {
                         // fallback to blocking

--- a/servlet-engine/src/main/java/io/micronaut/servlet/engine/DefaultServletHttpResponse.java
+++ b/servlet-engine/src/main/java/io/micronaut/servlet/engine/DefaultServletHttpResponse.java
@@ -35,15 +35,17 @@ import io.micronaut.http.codec.MediaTypeCodec;
 import io.micronaut.http.cookie.Cookie;
 import io.micronaut.http.exceptions.HttpStatusException;
 import io.micronaut.servlet.http.ServletHttpResponse;
-import org.reactivestreams.Publisher;
-import org.reactivestreams.Subscriber;
-import org.reactivestreams.Subscription;
-import reactor.core.publisher.Flux;
-import reactor.core.publisher.FluxSink;
-
 import jakarta.servlet.ServletOutputStream;
 import jakarta.servlet.WriteListener;
 import jakarta.servlet.http.HttpServletResponse;
+import org.reactivestreams.Publisher;
+import org.reactivestreams.Subscriber;
+import org.reactivestreams.Subscription;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.FluxSink;
+
 import java.io.BufferedWriter;
 import java.io.IOException;
 import java.io.OutputStream;
@@ -66,6 +68,8 @@ import java.util.stream.Collectors;
  */
 @Internal
 public class DefaultServletHttpResponse<B> implements ServletHttpResponse<HttpServletResponse, B> {
+
+    private static final Logger LOG = LoggerFactory.getLogger(DefaultServletHttpResponse.class);
 
     private static final byte[] EMPTY_ARRAY = "[]".getBytes();
 
@@ -199,7 +203,10 @@ public class DefaultServletHttpResponse<B> implements ServletHttpResponse<HttpSe
                     if (t instanceof HttpStatusException) {
                         maybeReportErrorDownstream(t);
                     } else {
-                        emitter.error(t);
+                        if (LOG.isWarnEnabled()) {
+                            LOG.warn("Reactive response received an error after some data has already been written. This error cannot be forwarded to the client.", t);
+                        }
+                        maybeReportErrorDownstream(new HttpStatusException(HttpStatus.INTERNAL_SERVER_ERROR, HttpStatus.INTERNAL_SERVER_ERROR.getReason()+ ": "+t.getMessage()));
                     }
                     subscription.cancel();
                 }

--- a/servlet-engine/src/main/java/io/micronaut/servlet/engine/DefaultServletHttpResponse.java
+++ b/servlet-engine/src/main/java/io/micronaut/servlet/engine/DefaultServletHttpResponse.java
@@ -206,7 +206,7 @@ public class DefaultServletHttpResponse<B> implements ServletHttpResponse<HttpSe
                         if (LOG.isWarnEnabled()) {
                             LOG.warn("Reactive response received an error after some data has already been written. This error cannot be forwarded to the client.", t);
                         }
-                        maybeReportErrorDownstream(new HttpStatusException(HttpStatus.INTERNAL_SERVER_ERROR, HttpStatus.INTERNAL_SERVER_ERROR.getReason()+ ": "+t.getMessage()));
+                        maybeReportErrorDownstream(new HttpStatusException(HttpStatus.INTERNAL_SERVER_ERROR, HttpStatus.INTERNAL_SERVER_ERROR.getReason() + ": " + t.getMessage()));
                     }
                     subscription.cancel();
                 }


### PR DESCRIPTION
Streaming reactive response body processing is updated to complete the response when an error signal is encountered.

This brings parity to the way streaming errors are handled in the Netty server implementation. Previously an error 
signal resulted in the response hanging and never completing.

This mostly fixes the TCK test failures encountered when trying to update to Micronaut Core 4.1.11 (#588), but one of the 
test methods in the TCK's `ErrorHandlerFluxTest` will need to be updated to detect the error properly with 
mid-stream errors and the way they get written to the servlet response.
