### PR TITLE
Stop publishing micronaut core dependencies as API

### DIFF
--- a/buildSrc/src/main/groovy/io.micronaut.build.internal.servlet.implementation.gradle
+++ b/buildSrc/src/main/groovy/io.micronaut.build.internal.servlet.implementation.gradle
@@ -6,7 +6,7 @@ dependencies {
     annotationProcessor mn.micronaut.graal
 
     api(projects.micronautServletEngine)
-    api mn.micronaut.http.server
+    implementation(mn.micronaut.http.server)
 
     compileOnly libs.graal.svm
 

--- a/servlet-core/build.gradle.kts
+++ b/servlet-core/build.gradle.kts
@@ -3,9 +3,9 @@ plugins {
 }
 
 dependencies {
-    api(mn.micronaut.inject)
-    api(mn.micronaut.http.server)
     compileOnly(mn.micronaut.json.core)
+    implementation(mn.micronaut.inject)
+    implementation(mn.micronaut.http.server)
     implementation(mn.micronaut.http.netty)
     implementation(mn.micronaut.router)
     implementation(mnReactor.micronaut.reactor)

--- a/servlet-engine/build.gradle
+++ b/servlet-engine/build.gradle
@@ -8,6 +8,7 @@ dependencies {
     api(projects.micronautServletCore)
     api libs.managed.servlet.api
 
+    implementation(mn.micronaut.http.server)
     implementation(mnReactor.micronaut.reactor)
     implementation mn.micronaut.discovery.core
     implementation mn.micronaut.jackson.core


### PR DESCRIPTION
This is pulling other versions of Micronaut into the classpath