### PR TITLE
Remove deprecations for Micronaut Framework 5 and document breaking changes

### DIFF
--- a/config/accepted-api-changes.json
+++ b/config/accepted-api-changes.json
@@ -203,5 +203,16 @@
     "type": "io.micronaut.servlet.http.ServletBodyBinder",
     "member": "Implemented interface io.micronaut.http.bind.binders.BodyArgumentBinder",
     "reason": "Core API change to DefaultBodyAnnotationBinder for Micronaut 4"
-  }]
+  },
+  {
+    "type": "io.micronaut.servlet.engine.DefaultServletHttpHandler",
+    "member": "Constructor io.micronaut.servlet.engine.DefaultServletHttpHandler(io.micronaut.context.ApplicationContext)",
+    "reason": "Removed deprecated code for Micronaut Framework 5."
+  },
+  {
+    "type": "io.micronaut.servlet.http.ServletHttpHandler",
+    "member": "Constructor io.micronaut.servlet.http.ServletHttpHandler(io.micronaut.context.ApplicationContext)",
+    "reason": "Removed deprecated code for Micronaut Framework 5."
+  }
+]
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
-projectVersion=4.6.1-SNAPSHOT
+projectVersion=5.0.0-SNAPSHOT
 projectGroup=io.micronaut.servlet
 
 title=Micronaut Servlet

--- a/servlet-core/src/main/java/io/micronaut/servlet/http/ServletHttpHandler.java
+++ b/servlet-core/src/main/java/io/micronaut/servlet/http/ServletHttpHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2020 original authors
+ * Copyright 2017-2024 original authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -116,17 +116,6 @@ public abstract class ServletHttpHandler<REQ, RES> implements AutoCloseable, Lif
         // hack for bug fixed in Micronaut 1.3.3
         applicationContext.getEnvironment()
             .addConverter(HttpRequest.class, HttpRequest.class, httpRequest -> httpRequest);
-    }
-
-    /**
-     * Default constructor.
-     *
-     * @param applicationContext The application context
-     * @deprecated Use {@link #ServletHttpHandler(ApplicationContext, ConversionService)}
-     */
-    @Deprecated
-    public ServletHttpHandler(ApplicationContext applicationContext) {
-        this(applicationContext, ConversionService.SHARED);
     }
 
     /**

--- a/servlet-engine/src/main/java/io/micronaut/servlet/engine/DefaultServletHttpHandler.java
+++ b/servlet-engine/src/main/java/io/micronaut/servlet/engine/DefaultServletHttpHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2020 original authors
+ * Copyright 2017-2024 original authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -20,7 +20,6 @@ import io.micronaut.core.convert.ConversionService;
 import io.micronaut.servlet.http.BodyBuilder;
 import io.micronaut.servlet.http.ServletExchange;
 import io.micronaut.servlet.http.ServletHttpHandler;
-
 import jakarta.inject.Singleton;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
@@ -41,17 +40,6 @@ public class DefaultServletHttpHandler extends ServletHttpHandler<HttpServletReq
      */
     public DefaultServletHttpHandler(ApplicationContext applicationContext, ConversionService conversionService) {
         super(applicationContext, conversionService);
-    }
-
-    /**
-     * Default constructor.
-     *
-     * @param applicationContext The application context
-     * @deprecated use {@link #DefaultServletHttpHandler(ApplicationContext, ConversionService)}
-     */
-    @Deprecated
-    public DefaultServletHttpHandler(ApplicationContext applicationContext) {
-        super(applicationContext, ConversionService.SHARED);
     }
 
     @Override

--- a/src/main/docs/guide/breaks.adoc
+++ b/src/main/docs/guide/breaks.adoc
@@ -1,6 +1,16 @@
-This section documents breaking changes between versions.
+This section documents breaking changes between Micronaut Servlet versions:
 
-== 3.3.4
+== Micronaut Servlet 5.0.0
+
+=== Deprecations
+
+- The Singleton constructor `io.micronaut.servlet.engine.DefaultServletHttpHandler(ApplicationContext) deprecated previously has been removed.
+`DefaultServletHttpHandler(ApplicationContext, ConversionService)` is used instead.
+
+- The abstract class constructor `io.micronaut.servlet.http.ServletHttpHandler(ApplicationContext)` deprecated previously has been removed.
+`ServletHttpHandler(ApplicationContext, ConversionService)` is used instead.
+
+== Micronaut Servlet 3.3.4
 
 === Binding network interface
 


### PR DESCRIPTION
closes #646 

Note: I created a new branch 4.6.x for Micronaut Framework 4 maintenance. Once this PR is merged master targets Micronaut Framework 5.