### PR TITLE
Support Virtual Threads in Jetty & Tomcat

### DIFF
--- a/http-server-jetty/src/test/groovy/io/micronaut/servlet/jetty/JettyVirtualThreadSpec.groovy
+++ b/http-server-jetty/src/test/groovy/io/micronaut/servlet/jetty/JettyVirtualThreadSpec.groovy
@@ -1,0 +1,21 @@
+package io.micronaut.servlet.jetty
+
+import io.micronaut.test.extensions.spock.annotation.MicronautTest
+import jakarta.inject.Inject
+import org.eclipse.jetty.server.Server
+import org.eclipse.jetty.util.thread.QueuedThreadPool
+import spock.lang.Requires
+import spock.lang.Specification
+
+@MicronautTest
+@Requires({ jvm.java21 })
+class JettyVirtualThreadSpec extends Specification {
+    @Inject Server server
+
+    void "test virtual thread enabled on JDK 21+"() {
+        expect:
+        server.threadPool instanceof QueuedThreadPool
+        server.threadPool.virtualThreadsExecutor != null
+
+    }
+}

--- a/http-server-tomcat/src/main/java/io/micronaut/servlet/tomcat/TomcatFactory.java
+++ b/http-server-tomcat/src/main/java/io/micronaut/servlet/tomcat/TomcatFactory.java
@@ -38,7 +38,6 @@ import org.apache.catalina.Context;
 import org.apache.catalina.Wrapper;
 import org.apache.catalina.connector.Connector;
 import org.apache.catalina.startup.Tomcat;
-import org.apache.coyote.ProtocolHandler;
 import org.apache.tomcat.util.net.SSLHostConfig;
 import org.apache.tomcat.util.net.SSLHostConfigCertificate;
 import org.slf4j.Logger;
@@ -53,8 +52,8 @@ import org.slf4j.LoggerFactory;
 @Factory
 public class TomcatFactory extends ServletServerFactory {
 
+    private static final String HTTPS = "HTTPS";
     private static final Logger LOG = LoggerFactory.getLogger(TomcatFactory.class);
-    public static final String HTTPS = "HTTPS";
 
     /**
      * Default constructor.

--- a/http-server-tomcat/src/main/java/io/micronaut/servlet/tomcat/TomcatFactory.java
+++ b/http-server-tomcat/src/main/java/io/micronaut/servlet/tomcat/TomcatFactory.java
@@ -15,6 +15,10 @@
  */
 package io.micronaut.servlet.tomcat;
 
+import io.micronaut.context.annotation.Requires;
+import io.micronaut.core.annotation.Nullable;
+import io.micronaut.core.util.StringUtils;
+import jakarta.inject.Named;
 import java.io.File;
 import java.util.List;
 
@@ -34,6 +38,7 @@ import org.apache.catalina.Context;
 import org.apache.catalina.Wrapper;
 import org.apache.catalina.connector.Connector;
 import org.apache.catalina.startup.Tomcat;
+import org.apache.coyote.ProtocolHandler;
 import org.apache.tomcat.util.net.SSLHostConfig;
 import org.apache.tomcat.util.net.SSLHostConfigCertificate;
 import org.slf4j.Logger;
@@ -49,6 +54,7 @@ import org.slf4j.LoggerFactory;
 public class TomcatFactory extends ServletServerFactory {
 
     private static final Logger LOG = LoggerFactory.getLogger(TomcatFactory.class);
+    public static final String HTTPS = "HTTPS";
 
     /**
      * Default constructor.
@@ -77,12 +83,16 @@ public class TomcatFactory extends ServletServerFactory {
      * The Tomcat server bean.
      *
      * @param connector The connector
+     * @param httpsConnector The HTTPS connector
      * @param configuration The servlet configuration
      * @return The Tomcat server
      */
     @Singleton
     @Primary
-    protected Tomcat tomcatServer(Connector connector, MicronautServletConfiguration configuration) {
+    protected Tomcat tomcatServer(
+        Connector connector,
+        @Named(HTTPS) @Nullable Connector httpsConnector,
+        MicronautServletConfiguration configuration) {
         configuration.setAsyncFileServingEnabled(false);
         Tomcat tomcat = new Tomcat();
         tomcat.setHostname(getConfiguredHost());
@@ -118,48 +128,7 @@ public class TomcatFactory extends ServletServerFactory {
         configuration.getMultipartConfigElement()
                 .ifPresent(servlet::setMultipartConfigElement);
 
-        SslConfiguration sslConfiguration = getSslConfiguration();
-        if (sslConfiguration.isEnabled()) {
-            String protocol = sslConfiguration.getProtocol().orElse("TLS");
-            int sslPort = sslConfiguration.getPort();
-            if (sslPort == SslConfiguration.DEFAULT_PORT && getEnvironment().getActiveNames().contains(Environment.TEST)) {
-                sslPort = 0;
-            }
-            Connector httpsConnector = new Connector();
-            SSLHostConfig sslHostConfig = new SSLHostConfig();
-            SSLHostConfigCertificate certificate = new SSLHostConfigCertificate(sslHostConfig, SSLHostConfigCertificate.Type.UNDEFINED);
-            sslHostConfig.addCertificate(certificate);
-            httpsConnector.addSslHostConfig(sslHostConfig);
-            httpsConnector.setPort(sslPort);
-            httpsConnector.setSecure(true);
-            httpsConnector.setScheme("https");
-            httpsConnector.setProperty("clientAuth", "false");
-            httpsConnector.setProperty("sslProtocol", protocol);
-            httpsConnector.setProperty("SSLEnabled", "true");
-            sslConfiguration.getCiphers().ifPresent(cyphers ->
-                sslHostConfig.setCiphers(String.join(",", cyphers))
-            );
-            sslConfiguration.getClientAuthentication().ifPresent(ca ->
-                httpsConnector.setProperty("clientAuth", ca == ClientAuthentication.WANT ? "want" : "true")
-            );
-
-
-            SslConfiguration.KeyStoreConfiguration keyStoreConfig = sslConfiguration.getKeyStore();
-            keyStoreConfig.getPassword().ifPresent(certificate::setCertificateKeystorePassword);
-            keyStoreConfig.getPath().ifPresent(certificate::setCertificateKeystoreFile);
-            keyStoreConfig.getProvider().ifPresent(certificate::setCertificateKeystorePassword);
-            keyStoreConfig.getType().ifPresent(certificate::setCertificateKeystoreType);
-
-            SslConfiguration.TrustStoreConfiguration trustStore = sslConfiguration.getTrustStore();
-            trustStore.getPassword().ifPresent(sslHostConfig::setTruststorePassword);
-            trustStore.getPath().ifPresent(sslHostConfig::setTruststoreFile);
-            trustStore.getProvider().ifPresent(sslHostConfig::setTruststoreProvider);
-            trustStore.getType().ifPresent(sslHostConfig::setTruststoreType);
-
-            SslConfiguration.KeyConfiguration keyConfig = sslConfiguration.getKey();
-            keyConfig.getAlias().ifPresent(certificate::setCertificateKeyAlias);
-            keyConfig.getPassword().ifPresent(certificate::setCertificateKeyPassword);
-
+        if (httpsConnector != null) {
             tomcat.getService().addConnector(httpsConnector);
         }
 
@@ -167,7 +136,7 @@ public class TomcatFactory extends ServletServerFactory {
     }
 
     /**
-     * @return Create the protocol.
+     * @return Create the connector.
      */
     @Singleton
     @Primary
@@ -177,4 +146,54 @@ public class TomcatFactory extends ServletServerFactory {
         return tomcatConnector;
     }
 
-}
+    /**
+     * The HTTPS connector.
+     * @param sslConfiguration The SSL configuration.
+     * @return The SSL connector
+     */
+    @Singleton
+    @Named(HTTPS)
+    @Requires(property = SslConfiguration.PREFIX + ".enabled", value = StringUtils.TRUE)
+    protected Connector sslConnector(SslConfiguration sslConfiguration) {
+        String protocol = sslConfiguration.getProtocol().orElse("TLS");
+        int sslPort = sslConfiguration.getPort();
+        if (sslPort == SslConfiguration.DEFAULT_PORT && getEnvironment().getActiveNames().contains(Environment.TEST)) {
+            sslPort = 0;
+        }
+        Connector httpsConnector = new Connector();
+        SSLHostConfig sslHostConfig = new SSLHostConfig();
+        SSLHostConfigCertificate certificate = new SSLHostConfigCertificate(sslHostConfig, SSLHostConfigCertificate.Type.UNDEFINED);
+        sslHostConfig.addCertificate(certificate);
+        httpsConnector.addSslHostConfig(sslHostConfig);
+        httpsConnector.setPort(sslPort);
+        httpsConnector.setSecure(true);
+        httpsConnector.setScheme("https");
+        httpsConnector.setProperty("clientAuth", "false");
+        httpsConnector.setProperty("sslProtocol", protocol);
+        httpsConnector.setProperty("SSLEnabled", "true");
+        sslConfiguration.getCiphers().ifPresent(cyphers ->
+            sslHostConfig.setCiphers(String.join(",", cyphers))
+        );
+        sslConfiguration.getClientAuthentication().ifPresent(ca ->
+            httpsConnector.setProperty("clientAuth", ca == ClientAuthentication.WANT ? "want" : "true")
+        );
+
+
+        SslConfiguration.KeyStoreConfiguration keyStoreConfig = sslConfiguration.getKeyStore();
+        keyStoreConfig.getPassword().ifPresent(certificate::setCertificateKeystorePassword);
+        keyStoreConfig.getPath().ifPresent(certificate::setCertificateKeystoreFile);
+        keyStoreConfig.getProvider().ifPresent(certificate::setCertificateKeystorePassword);
+        keyStoreConfig.getType().ifPresent(certificate::setCertificateKeystoreType);
+
+        SslConfiguration.TrustStoreConfiguration trustStore = sslConfiguration.getTrustStore();
+        trustStore.getPassword().ifPresent(sslHostConfig::setTruststorePassword);
+        trustStore.getPath().ifPresent(sslHostConfig::setTruststoreFile);
+        trustStore.getProvider().ifPresent(sslHostConfig::setTruststoreProvider);
+        trustStore.getType().ifPresent(sslHostConfig::setTruststoreType);
+
+        SslConfiguration.KeyConfiguration keyConfig = sslConfiguration.getKey();
+        keyConfig.getAlias().ifPresent(certificate::setCertificateKeyAlias);
+        keyConfig.getPassword().ifPresent(certificate::setCertificateKeyPassword);
+        return httpsConnector;
+    }
+ }

--- a/http-server-tomcat/src/main/java/io/micronaut/servlet/tomcat/TomcatVirtualThreadEnabler.java
+++ b/http-server-tomcat/src/main/java/io/micronaut/servlet/tomcat/TomcatVirtualThreadEnabler.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2017-2024 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.servlet.tomcat;
+
+import io.micronaut.context.ApplicationContext;
+import io.micronaut.context.annotation.Requires;
+import io.micronaut.context.event.BeanCreatedEvent;
+import io.micronaut.context.event.BeanCreatedEventListener;
+import io.micronaut.core.annotation.NonNull;
+import io.micronaut.inject.qualifiers.Qualifiers;
+import io.micronaut.scheduling.TaskExecutors;
+import io.micronaut.servlet.http.ServletConfiguration;
+import jakarta.inject.Singleton;
+import java.util.concurrent.ExecutorService;
+import org.apache.catalina.connector.Connector;
+import org.apache.coyote.ProtocolHandler;
+import org.apache.tomcat.util.threads.VirtualThreadExecutor;
+
+/**
+ * Enables virtual thread configuration if enabled.
+ */
+@Requires(sdk = Requires.Sdk.JAVA, version = "21")
+@Singleton
+public class TomcatVirtualThreadEnabler implements BeanCreatedEventListener<Connector> {
+    private final ServletConfiguration servletConfiguration;
+    private final ApplicationContext applicationContext;
+
+    public TomcatVirtualThreadEnabler(ServletConfiguration servletConfiguration, ApplicationContext applicationContext) {
+        this.servletConfiguration = servletConfiguration;
+        this.applicationContext = applicationContext;
+    }
+
+    @Override
+    public Connector onCreated(@NonNull BeanCreatedEvent<Connector> event) {
+        Connector connector = event.getBean();
+        if (servletConfiguration.isEnableVirtualThreads()) {
+            ProtocolHandler protocolHandler = connector.getProtocolHandler();
+            ExecutorService executorService = applicationContext.getBean(ExecutorService.class, Qualifiers.byName(TaskExecutors.BLOCKING));
+            protocolHandler.setExecutor(executorService);
+        }
+        return connector;
+    }
+}

--- a/http-server-tomcat/src/main/java/io/micronaut/servlet/tomcat/TomcatVirtualThreadEnabler.java
+++ b/http-server-tomcat/src/main/java/io/micronaut/servlet/tomcat/TomcatVirtualThreadEnabler.java
@@ -30,7 +30,7 @@ import org.apache.tomcat.util.threads.VirtualThreadExecutor;
  */
 @Requires(sdk = Requires.Sdk.JAVA, version = "21")
 @Singleton
-public class TomcatVirtualThreadEnabler implements BeanCreatedEventListener<Connector> {
+class TomcatVirtualThreadEnabler implements BeanCreatedEventListener<Connector> {
     private final ServletConfiguration servletConfiguration;
 
     public TomcatVirtualThreadEnabler(ServletConfiguration servletConfiguration) {

--- a/http-server-tomcat/src/main/java/io/micronaut/servlet/tomcat/TomcatVirtualThreadEnabler.java
+++ b/http-server-tomcat/src/main/java/io/micronaut/servlet/tomcat/TomcatVirtualThreadEnabler.java
@@ -15,16 +15,12 @@
  */
 package io.micronaut.servlet.tomcat;
 
-import io.micronaut.context.ApplicationContext;
 import io.micronaut.context.annotation.Requires;
 import io.micronaut.context.event.BeanCreatedEvent;
 import io.micronaut.context.event.BeanCreatedEventListener;
 import io.micronaut.core.annotation.NonNull;
-import io.micronaut.inject.qualifiers.Qualifiers;
-import io.micronaut.scheduling.TaskExecutors;
 import io.micronaut.servlet.http.ServletConfiguration;
 import jakarta.inject.Singleton;
-import java.util.concurrent.ExecutorService;
 import org.apache.catalina.connector.Connector;
 import org.apache.coyote.ProtocolHandler;
 import org.apache.tomcat.util.threads.VirtualThreadExecutor;
@@ -36,11 +32,9 @@ import org.apache.tomcat.util.threads.VirtualThreadExecutor;
 @Singleton
 public class TomcatVirtualThreadEnabler implements BeanCreatedEventListener<Connector> {
     private final ServletConfiguration servletConfiguration;
-    private final ApplicationContext applicationContext;
 
-    public TomcatVirtualThreadEnabler(ServletConfiguration servletConfiguration, ApplicationContext applicationContext) {
+    public TomcatVirtualThreadEnabler(ServletConfiguration servletConfiguration) {
         this.servletConfiguration = servletConfiguration;
-        this.applicationContext = applicationContext;
     }
 
     @Override
@@ -48,8 +42,7 @@ public class TomcatVirtualThreadEnabler implements BeanCreatedEventListener<Conn
         Connector connector = event.getBean();
         if (servletConfiguration.isEnableVirtualThreads()) {
             ProtocolHandler protocolHandler = connector.getProtocolHandler();
-            ExecutorService executorService = applicationContext.getBean(ExecutorService.class, Qualifiers.byName(TaskExecutors.BLOCKING));
-            protocolHandler.setExecutor(executorService);
+            protocolHandler.setExecutor(new VirtualThreadExecutor("tomcat-handler-"));
         }
         return connector;
     }

--- a/http-server-tomcat/src/test/groovy/io/micronaut/servlet/tomcat/TomcatVirtualThreadSpec.groovy
+++ b/http-server-tomcat/src/test/groovy/io/micronaut/servlet/tomcat/TomcatVirtualThreadSpec.groovy
@@ -1,0 +1,23 @@
+package io.micronaut.servlet.tomcat
+
+import io.micronaut.scheduling.TaskExecutors
+import io.micronaut.test.extensions.spock.annotation.MicronautTest
+import jakarta.inject.Inject
+import jakarta.inject.Named
+import org.apache.catalina.startup.Tomcat
+import spock.lang.Requires
+import spock.lang.Specification
+
+import java.util.concurrent.ExecutorService
+
+@MicronautTest
+@Requires({ jvm.java21 })
+class TomcatVirtualThreadSpec  extends Specification {
+    @Inject Tomcat server
+    @Inject @Named(TaskExecutors.BLOCKING) ExecutorService taskExecutor
+
+    void "test virtual thread enabled on JDK 21+"() {
+        expect:
+        server.connector.protocolHandler.executor.is(taskExecutor)
+    }
+}

--- a/http-server-tomcat/src/test/groovy/io/micronaut/servlet/tomcat/TomcatVirtualThreadSpec.groovy
+++ b/http-server-tomcat/src/test/groovy/io/micronaut/servlet/tomcat/TomcatVirtualThreadSpec.groovy
@@ -1,23 +1,20 @@
 package io.micronaut.servlet.tomcat
 
-import io.micronaut.scheduling.TaskExecutors
+
 import io.micronaut.test.extensions.spock.annotation.MicronautTest
 import jakarta.inject.Inject
-import jakarta.inject.Named
 import org.apache.catalina.startup.Tomcat
+import org.apache.tomcat.util.threads.VirtualThreadExecutor
 import spock.lang.Requires
 import spock.lang.Specification
-
-import java.util.concurrent.ExecutorService
 
 @MicronautTest
 @Requires({ jvm.java21 })
 class TomcatVirtualThreadSpec  extends Specification {
     @Inject Tomcat server
-    @Inject @Named(TaskExecutors.BLOCKING) ExecutorService taskExecutor
 
     void "test virtual thread enabled on JDK 21+"() {
         expect:
-        server.connector.protocolHandler.executor.is(taskExecutor)
+        server.connector.protocolHandler.executor instanceof VirtualThreadExecutor
     }
 }

--- a/servlet-core/src/main/java/io/micronaut/servlet/http/ServletConfiguration.java
+++ b/servlet-core/src/main/java/io/micronaut/servlet/http/ServletConfiguration.java
@@ -38,4 +38,16 @@ public interface ServletConfiguration {
     default boolean isAsyncSupported() {
         return true;
     }
+
+    /**
+     * Whether to enable virtual thread support if available.
+     *
+     * <p>If virtual threads are not available this option does nothing.</p>
+     *
+     * @return True if they should be enabled
+     * @since 4.8.0
+     */
+    default boolean isEnableVirtualThreads() {
+        return true;
+    }
 }

--- a/servlet-engine/src/main/java/io/micronaut/servlet/engine/MicronautServletConfiguration.java
+++ b/servlet-engine/src/main/java/io/micronaut/servlet/engine/MicronautServletConfiguration.java
@@ -50,6 +50,7 @@ public class MicronautServletConfiguration implements Named, ServletConfiguratio
     private boolean asyncFileServingEnabled = true;
 
     private boolean asyncSupported = true;
+    private boolean enableVirtualThreads = true;
 
 
     /**
@@ -103,6 +104,20 @@ public class MicronautServletConfiguration implements Named, ServletConfiguratio
         if (asyncSupported != null) {
             this.asyncSupported = asyncSupported;
         }
+    }
+
+    @Override
+    public boolean isEnableVirtualThreads() {
+        return this.enableVirtualThreads;
+    }
+
+    /**
+     * Whether virtual threads are enabled.
+     * @param enableVirtualThreads True if they are enabled
+     * @since 4.8.0
+     */
+    public void setEnableVirtualThreads(boolean enableVirtualThreads) {
+        this.enableVirtualThreads = enableVirtualThreads;
     }
 
     /**


### PR DESCRIPTION
Allows enabling virtual thread support for Jetty and Tomcat.

Undertow has issues with Virtual threads so not implemented. See https://github.com/spring-projects/spring-boot/issues/39812