### PR TITLE
Make servlet more flexible / support servlet annotations

### DIFF
--- a/http-server-jetty/build.gradle
+++ b/http-server-jetty/build.gradle
@@ -7,6 +7,7 @@ dependencies {
     testImplementation libs.bcpkix
     testCompileOnly(mnValidation.micronaut.validation.processor)
     testAnnotationProcessor(mnValidation.micronaut.validation.processor)
+    testAnnotationProcessor(projects.micronautServletProcessor)
     testImplementation(mnValidation.micronaut.validation)
     testImplementation(mnSerde.micronaut.serde.jackson)
     testImplementation(mnLogging.logback.classic)

--- a/http-server-jetty/src/main/java/io/micronaut/servlet/jetty/JettyFactory.java
+++ b/http-server-jetty/src/main/java/io/micronaut/servlet/jetty/JettyFactory.java
@@ -266,7 +266,7 @@ public class JettyFactory extends ServletServerFactory {
         if (https != null) {
             server.addConnector(https); // must be first
             if (serverConfiguration.isDualProtocol()) {
-                server.addConnector(https);
+                server.addConnector(http);
             }
         } else {
             server.addConnector(http);

--- a/http-server-jetty/src/main/java/io/micronaut/servlet/jetty/JettyServer.java
+++ b/http-server-jetty/src/main/java/io/micronaut/servlet/jetty/JettyServer.java
@@ -61,7 +61,8 @@ public class JettyServer extends AbstractServletServer<Server> {
 
     @Override
     public int getPort() {
-        return getServer().getURI().getPort();
+        Server server = getServer();
+        return server.getURI().getPort();
     }
 
     @Override

--- a/http-server-jetty/src/test/groovy/io/micronaut/servlet/jetty/JettyServletAnnotationSpec.groovy
+++ b/http-server-jetty/src/test/groovy/io/micronaut/servlet/jetty/JettyServletAnnotationSpec.groovy
@@ -1,0 +1,31 @@
+package io.micronaut.servlet.jetty
+
+import io.micronaut.http.client.HttpClient
+import io.micronaut.http.client.annotation.Client
+import io.micronaut.test.extensions.spock.annotation.MicronautTest
+import jakarta.inject.Inject
+import spock.lang.Specification
+
+@MicronautTest
+class JettyServletAnnotationSpec extends Specification {
+    @Inject
+    @Client("/")
+    HttpClient rxClient
+
+    @Inject MyListener myListener
+
+    void "test extra servlet"() {
+        expect:
+        rxClient.toBlocking().retrieve("/extra-servlet", String) == 'My Servlet!'
+    }
+
+    void "test extra filter"() {
+        expect:
+        rxClient.toBlocking().retrieve("/extra-filter", String) == 'My Filter!'
+    }
+
+    void "test extra listener"() {
+        expect:
+        myListener.initialized
+    }
+}

--- a/http-server-jetty/src/test/java/io/micronaut/servlet/jetty/MyExtraFilter.java
+++ b/http-server-jetty/src/test/java/io/micronaut/servlet/jetty/MyExtraFilter.java
@@ -1,0 +1,27 @@
+package io.micronaut.servlet.jetty;
+
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.GenericFilter;
+import jakarta.servlet.GenericServlet;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.ServletRequest;
+import jakarta.servlet.ServletResponse;
+import jakarta.servlet.annotation.WebFilter;
+import jakarta.servlet.annotation.WebServlet;
+import java.io.IOException;
+import java.io.PrintWriter;
+
+@WebFilter(value = "/extra-filter/*")
+public class MyExtraFilter extends GenericFilter {
+
+    @Override
+    public void doFilter(ServletRequest request, ServletResponse res, FilterChain chain) throws IOException, ServletException {
+        if (!Boolean.TRUE.equals(request.getAttribute("runFirst"))) {
+            throw new IllegalStateException("Should have run second");
+        }
+        PrintWriter writer = res.getWriter();
+        res.setContentType("text/plain");
+        writer.write("My Filter!");
+        writer.flush();
+    }
+}

--- a/http-server-jetty/src/test/java/io/micronaut/servlet/jetty/MyExtraFilter.java
+++ b/http-server-jetty/src/test/java/io/micronaut/servlet/jetty/MyExtraFilter.java
@@ -19,6 +19,7 @@ public class MyExtraFilter extends GenericFilter {
         if (!Boolean.TRUE.equals(request.getAttribute("runFirst"))) {
             throw new IllegalStateException("Should have run second");
         }
+        request.setAttribute("runSecond", true);
         PrintWriter writer = res.getWriter();
         res.setContentType("text/plain");
         writer.write("My Filter!");

--- a/http-server-jetty/src/test/java/io/micronaut/servlet/jetty/MyExtraServlet.java
+++ b/http-server-jetty/src/test/java/io/micronaut/servlet/jetty/MyExtraServlet.java
@@ -12,9 +12,10 @@ import java.io.PrintWriter;
 public class MyExtraServlet extends GenericServlet {
     @Override
     public void service(ServletRequest req, ServletResponse res) throws ServletException, IOException {
-        PrintWriter writer = res.getWriter();
-        res.setContentType("text/plain");
-        writer.write("My Servlet!");
-        writer.flush();
+        try (PrintWriter writer = res.getWriter()) {
+            res.setContentType("text/plain");
+            writer.write("My Servlet!");
+            writer.flush();
+        };
     }
 }

--- a/http-server-jetty/src/test/java/io/micronaut/servlet/jetty/MyExtraServlet.java
+++ b/http-server-jetty/src/test/java/io/micronaut/servlet/jetty/MyExtraServlet.java
@@ -12,6 +12,10 @@ import java.io.PrintWriter;
 public class MyExtraServlet extends GenericServlet {
     @Override
     public void service(ServletRequest req, ServletResponse res) throws ServletException, IOException {
+        if (!Boolean.TRUE.equals(req.getAttribute("runFirst")) ||
+            !Boolean.TRUE.equals(req.getAttribute("runSecond"))) {
+            throw new IllegalStateException("Should have run last");
+        }
         try (PrintWriter writer = res.getWriter()) {
             res.setContentType("text/plain");
             writer.write("My Servlet!");

--- a/http-server-jetty/src/test/java/io/micronaut/servlet/jetty/MyExtraServlet.java
+++ b/http-server-jetty/src/test/java/io/micronaut/servlet/jetty/MyExtraServlet.java
@@ -1,0 +1,20 @@
+package io.micronaut.servlet.jetty;
+
+import jakarta.servlet.GenericServlet;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.ServletRequest;
+import jakarta.servlet.ServletResponse;
+import jakarta.servlet.annotation.WebServlet;
+import java.io.IOException;
+import java.io.PrintWriter;
+
+@WebServlet(value = "/extra-servlet/*")
+public class MyExtraServlet extends GenericServlet {
+    @Override
+    public void service(ServletRequest req, ServletResponse res) throws ServletException, IOException {
+        PrintWriter writer = res.getWriter();
+        res.setContentType("text/plain");
+        writer.write("My Servlet!");
+        writer.flush();
+    }
+}

--- a/http-server-jetty/src/test/java/io/micronaut/servlet/jetty/MyFilterFactory.java
+++ b/http-server-jetty/src/test/java/io/micronaut/servlet/jetty/MyFilterFactory.java
@@ -15,7 +15,7 @@ import java.io.IOException;
 @Factory
 public class MyFilterFactory {
 
-    @ServletFilterBean(filterName = "another", value = "/extra-filter/*")
+    @ServletFilterBean(filterName = "another", value = {"/extra-filter/*", "/extra-servlet/*"})
     @Order(Ordered.HIGHEST_PRECEDENCE)
     Filter myOtherFilter() {
         return new GenericFilter() {

--- a/http-server-jetty/src/test/java/io/micronaut/servlet/jetty/MyFilterFactory.java
+++ b/http-server-jetty/src/test/java/io/micronaut/servlet/jetty/MyFilterFactory.java
@@ -1,0 +1,29 @@
+package io.micronaut.servlet.jetty;
+
+import io.micronaut.context.annotation.Factory;
+import io.micronaut.core.annotation.Order;
+import io.micronaut.core.order.Ordered;
+import io.micronaut.servlet.engine.annotation.ServletFilterBean;
+import jakarta.servlet.Filter;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.GenericFilter;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.ServletRequest;
+import jakarta.servlet.ServletResponse;
+import java.io.IOException;
+
+@Factory
+public class MyFilterFactory {
+
+    @ServletFilterBean(filterName = "another", value = "/extra-filter/*")
+    @Order(Ordered.HIGHEST_PRECEDENCE)
+    Filter myOtherFilter() {
+        return new GenericFilter() {
+            @Override
+            public void doFilter(ServletRequest request, ServletResponse response, FilterChain chain) throws ServletException, IOException {
+                request.setAttribute("runFirst", true);
+                chain.doFilter(request, response);
+            }
+        };
+    }
+}

--- a/http-server-jetty/src/test/java/io/micronaut/servlet/jetty/MyLastFilter.java
+++ b/http-server-jetty/src/test/java/io/micronaut/servlet/jetty/MyLastFilter.java
@@ -1,0 +1,25 @@
+package io.micronaut.servlet.jetty;
+
+
+import io.micronaut.core.annotation.Order;
+import io.micronaut.core.order.Ordered;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.GenericFilter;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.ServletRequest;
+import jakarta.servlet.ServletResponse;
+import jakarta.servlet.annotation.WebFilter;
+import java.io.IOException;
+
+@WebFilter(value = {"/extra-filter/*", "/extra-servlet/*"})
+@Order(Ordered.LOWEST_PRECEDENCE)
+public class MyLastFilter extends GenericFilter {
+    @Override
+    public void doFilter(ServletRequest request, ServletResponse response, FilterChain chain) throws IOException, ServletException {
+        if (!Boolean.TRUE.equals(request.getAttribute("runFirst"))) {
+            throw new IllegalStateException("Should have run last");
+        }
+        request.setAttribute("runSecond", true);
+        chain.doFilter(request, response);
+    }
+}

--- a/http-server-jetty/src/test/java/io/micronaut/servlet/jetty/MyListener.java
+++ b/http-server-jetty/src/test/java/io/micronaut/servlet/jetty/MyListener.java
@@ -1,14 +1,12 @@
 package io.micronaut.servlet.jetty;
 
-import jakarta.inject.Singleton;
 import jakarta.servlet.ServletContextEvent;
 import jakarta.servlet.ServletContextListener;
 import jakarta.servlet.annotation.WebListener;
 
 @WebListener
-@Singleton
 public class MyListener implements ServletContextListener {
-    public boolean initialized;
+    public static boolean initialized;
 
     @Override
     public void contextInitialized(ServletContextEvent sce) {

--- a/http-server-jetty/src/test/java/io/micronaut/servlet/jetty/MyListener.java
+++ b/http-server-jetty/src/test/java/io/micronaut/servlet/jetty/MyListener.java
@@ -1,0 +1,17 @@
+package io.micronaut.servlet.jetty;
+
+import jakarta.inject.Singleton;
+import jakarta.servlet.ServletContextEvent;
+import jakarta.servlet.ServletContextListener;
+import jakarta.servlet.annotation.WebListener;
+
+@WebListener
+@Singleton
+public class MyListener implements ServletContextListener {
+    public boolean initialized;
+
+    @Override
+    public void contextInitialized(ServletContextEvent sce) {
+        initialized = true;
+    }
+}

--- a/http-server-tomcat/src/main/java/io/micronaut/servlet/tomcat/TomcatFactory.java
+++ b/http-server-tomcat/src/main/java/io/micronaut/servlet/tomcat/TomcatFactory.java
@@ -42,8 +42,6 @@ import org.apache.catalina.connector.Connector;
 import org.apache.catalina.startup.Tomcat;
 import org.apache.tomcat.util.net.SSLHostConfig;
 import org.apache.tomcat.util.net.SSLHostConfigCertificate;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 /**
  * Factory for the {@link Tomcat} instance.
@@ -83,14 +81,13 @@ public class TomcatFactory extends ServletServerFactory {
      * The Tomcat server bean.
      *
      * @param connector      The connector
-     * @param httpsConnector The HTTPS connector
      * @param configuration  The servlet configuration
      * @return The Tomcat server
      */
     protected Tomcat tomcatServer(Connector connector, MicronautServletConfiguration configuration) {
         return tomcatServer(
             connector,
-            getApplicationContext().getBean(Connector.class, Qualifiers.byName(HTTPS))
+            getApplicationContext().getBean(Connector.class, Qualifiers.byName(HTTPS)),
             configuration,
             getApplicationContext().getBean(MicronautServletInitializer.class));
     }

--- a/http-server-undertow/src/main/java/io/micronaut/servlet/undertow/UndertowFactory.java
+++ b/http-server-undertow/src/main/java/io/micronaut/servlet/undertow/UndertowFactory.java
@@ -115,7 +115,7 @@ public class UndertowFactory extends ServletServerFactory {
         if (sslConfiguration.isEnabled()) {
             int sslPort = sslConfiguration.getPort();
             if (sslPort == SslConfiguration.DEFAULT_PORT && getEnvironment().getActiveNames().contains(Environment.TEST)) {
-                sslPort = SocketUtils.findAvailableTcpPort();
+                sslPort = 0; // random port
             }
             int finalSslPort = sslPort;
             build(sslConfiguration).ifPresent(sslContext ->

--- a/servlet-engine/build.gradle
+++ b/servlet-engine/build.gradle
@@ -4,6 +4,7 @@ plugins {
 
 dependencies {
     annotationProcessor mn.micronaut.graal
+    annotationProcessor(projects.micronautServletProcessor)
 
     api(projects.micronautServletCore)
     api libs.managed.servlet.api

--- a/servlet-engine/src/main/java/io/micronaut/servlet/engine/DefaultMicronautServlet.java
+++ b/servlet-engine/src/main/java/io/micronaut/servlet/engine/DefaultMicronautServlet.java
@@ -20,7 +20,9 @@ import io.micronaut.context.ApplicationContextBuilder;
 import io.micronaut.context.env.Environment;
 import io.micronaut.core.annotation.TypeHint;
 
+import jakarta.inject.Inject;
 import jakarta.servlet.ServletContext;
+import jakarta.servlet.annotation.WebServlet;
 import jakarta.servlet.http.HttpServlet;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
@@ -33,6 +35,10 @@ import java.util.Objects;
  * @since 1.0
  */
 @TypeHint(DefaultMicronautServlet.class)
+@WebServlet(
+    name = DefaultMicronautServlet.NAME,
+    loadOnStartup = 1
+)
 public class DefaultMicronautServlet extends HttpServlet {
     /**
      * The name of the servlet.
@@ -51,6 +57,7 @@ public class DefaultMicronautServlet extends HttpServlet {
      * Constructor that takes an application context.
      * @param applicationContext The application context.
      */
+    @Inject
     public DefaultMicronautServlet(ApplicationContext applicationContext) {
         this.applicationContext = Objects.requireNonNull(applicationContext, "The application context cannot be null");
     }

--- a/servlet-engine/src/main/java/io/micronaut/servlet/engine/MicronautServletConfiguration.java
+++ b/servlet-engine/src/main/java/io/micronaut/servlet/engine/MicronautServletConfiguration.java
@@ -23,7 +23,6 @@ import io.micronaut.core.annotation.NonNull;
 import io.micronaut.core.annotation.Nullable;
 import io.micronaut.core.bind.annotation.Bindable;
 import io.micronaut.core.naming.Named;
-import io.micronaut.core.util.StringUtils;
 import io.micronaut.http.server.HttpServerConfiguration;
 import io.micronaut.servlet.http.ServletConfiguration;
 

--- a/servlet-engine/src/main/java/io/micronaut/servlet/engine/annotation/ServletBean.java
+++ b/servlet-engine/src/main/java/io/micronaut/servlet/engine/annotation/ServletBean.java
@@ -1,0 +1,85 @@
+/*
+ * Copyright 2017-2024 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.servlet.engine.annotation;
+
+import io.micronaut.context.annotation.AliasFor;
+import io.micronaut.context.annotation.Bean;
+import jakarta.servlet.annotation.WebInitParam;
+import jakarta.servlet.annotation.WebServlet;
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Variant of {@link jakarta.servlet.annotation.WebServlet} applicable to factory methods.
+ */
+@Documented
+@Target(ElementType.METHOD)
+@Retention(RetentionPolicy.RUNTIME)
+@Bean
+public @interface ServletBean {
+    /**
+     * The name of the servlet.
+     *
+     * @return the name of the servlet
+     */
+    @AliasFor(annotation = WebServlet.class, member = "name")
+    String name();
+
+    /**
+     * The URL patterns of the servlet.
+     *
+     * @return the URL patterns of the servlet
+     */
+    @AliasFor(annotation = WebServlet.class, member = "value")
+    String[] value() default {};
+
+    /**
+     * The URL patterns of the servlet.
+     *
+     * @return the URL patterns of the servlet
+     */
+    @AliasFor(annotation = WebServlet.class, member = "value")
+    String[] urlPatterns() default {};
+
+    /**
+     * The load-on-startup order of the servlet.
+     *
+     * @return the load-on-startup order of the servlet
+     */
+    @AliasFor(annotation = WebServlet.class, member = "loadOnStartup")
+    int loadOnStartup() default -1;
+
+    /**
+     * The init parameters of the servlet.
+     *
+     * @return the init parameters of the servlet
+     */
+    @AliasFor(annotation = WebServlet.class, member = "initParams")
+    WebInitParam[] initParams() default {};
+
+    /**
+     * Declares whether the servlet supports asynchronous operation mode.
+     *
+     * @return {@code true} if the servlet supports asynchronous operation mode
+     * @see jakarta.servlet.ServletRequest#startAsync
+     * @see jakarta.servlet.ServletRequest#startAsync( jakarta.servlet.ServletRequest,jakarta.servlet.ServletResponse)
+     */
+    @AliasFor(annotation = WebServlet.class, member = "asyncSupported")
+    boolean asyncSupported() default false;
+}

--- a/servlet-engine/src/main/java/io/micronaut/servlet/engine/annotation/ServletFilterBean.java
+++ b/servlet-engine/src/main/java/io/micronaut/servlet/engine/annotation/ServletFilterBean.java
@@ -1,0 +1,87 @@
+/*
+ * Copyright 2017-2024 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.servlet.engine.annotation;
+
+import io.micronaut.context.annotation.AliasFor;
+import io.micronaut.context.annotation.Bean;
+import io.micronaut.core.annotation.AnnotationMetadata;
+import jakarta.servlet.DispatcherType;
+import jakarta.servlet.annotation.WebFilter;
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Variant of {@link jakarta.servlet.annotation.WebFilter} applicable to factory methods.
+ */
+@Documented
+@Target(ElementType.METHOD)
+@Retention(RetentionPolicy.RUNTIME)
+@Bean
+public @interface ServletFilterBean {
+    /**
+     * The name of the filter.
+     *
+     * @return the name of the filter
+     */
+    @AliasFor(annotation = WebFilter.class, member = "filterName")
+    String filterName();
+
+    /**
+     * The names of the servlets to which the filter applies.
+     *
+     * @return the names of the servlets to which the filter applies
+     */
+    @AliasFor(annotation = WebFilter.class, member = "servletNames")
+    String[] servletNames() default {};
+
+    /**
+     * The URL patterns to which the filter applies The default value is an empty array.
+     *
+     * @return the URL patterns to which the filter applies
+     */
+    @AliasFor(annotation = WebFilter.class, member = AnnotationMetadata.VALUE_MEMBER)
+    String[] value() default {};
+
+    /**
+     * The URL patterns to which the filter applies.
+     *
+     * @return the URL patterns to which the filter applies
+     */
+    @AliasFor(annotation = WebFilter.class, member = AnnotationMetadata.VALUE_MEMBER)
+    String[] urlPatterns() default {};
+
+    /**
+     * The dispatcher types to which the filter applies.
+     *
+     * @return the dispatcher types to which the filter applies
+     */
+    @AliasFor(annotation = WebFilter.class, member = "dispatcherTypes")
+    DispatcherType[] dispatcherTypes() default { DispatcherType.REQUEST };
+
+    /**
+     * Declares whether the filter supports asynchronous operation mode.
+     *
+     * @return {@code true} if the filter supports asynchronous operation mode
+     * @see jakarta.servlet.ServletRequest#startAsync
+     * @see jakarta.servlet.ServletRequest#startAsync( jakarta.servlet.ServletRequest,jakarta.servlet.ServletResponse)
+     */
+    @AliasFor(annotation = WebFilter.class, member = "asyncSupported")
+    boolean asyncSupported() default false;
+
+}

--- a/servlet-engine/src/main/java/io/micronaut/servlet/engine/initializer/MicronautServletInitializer.java
+++ b/servlet-engine/src/main/java/io/micronaut/servlet/engine/initializer/MicronautServletInitializer.java
@@ -17,12 +17,39 @@ package io.micronaut.servlet.engine.initializer;
 
 import io.micronaut.context.ApplicationContext;
 import io.micronaut.context.ApplicationContextBuilder;
+import io.micronaut.context.BeanRegistration;
+import io.micronaut.context.annotation.Prototype;
+import io.micronaut.core.annotation.AnnotationValue;
+import io.micronaut.core.annotation.NonNull;
+import io.micronaut.core.util.ArrayUtils;
+import io.micronaut.core.util.StringUtils;
+import io.micronaut.inject.BeanDefinition;
+import io.micronaut.inject.BeanIdentifier;
+import io.micronaut.inject.qualifiers.Qualifiers;
 import io.micronaut.servlet.engine.DefaultMicronautServlet;
 import io.micronaut.servlet.engine.MicronautServletConfiguration;
+import jakarta.inject.Inject;
+import jakarta.servlet.DispatcherType;
+import jakarta.servlet.Filter;
+import jakarta.servlet.FilterRegistration;
+import jakarta.servlet.MultipartConfigElement;
+import jakarta.servlet.Servlet;
 import jakarta.servlet.ServletContainerInitializer;
 import jakarta.servlet.ServletContext;
 import jakarta.servlet.ServletRegistration;
 import jakarta.servlet.ServletSecurityElement;
+import jakarta.servlet.annotation.MultipartConfig;
+import jakarta.servlet.annotation.ServletSecurity;
+import jakarta.servlet.annotation.WebFilter;
+import jakarta.servlet.annotation.WebInitParam;
+import jakarta.servlet.annotation.WebListener;
+import jakarta.servlet.annotation.WebServlet;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.EnumSet;
+import java.util.EventListener;
+import java.util.List;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -37,25 +64,184 @@ import static io.micronaut.core.util.StringUtils.isNotEmpty;
  * @author graemerocher
  * @since 1.0.0
  */
+@Prototype
 public class MicronautServletInitializer implements ServletContainerInitializer {
 
     private static final Logger LOG = LoggerFactory.getLogger(MicronautServletInitializer.class);
+    private static final AnnotationValue<WebServlet> EMPTY_WEB_SERVLET = new AnnotationValue<>(WebServlet.class.getName());
+    private static final String MEMBER_URL_PATTERNS = "urlPatterns";
+    private static final String MEMBER_LOAD_ON_STARTUP = "loadOnStartup";
+    private static final String MEMBER_ASYNC_SUPPORTED = "asyncSupported";
+    private static final String MEMBER_INIT_PARAMS = "initParams";
+    private static final DispatcherType[] DEFAULT_DISPATCHER_TYPES = {DispatcherType.REQUEST};
+    private ApplicationContext applicationContext;
+    private List<String> micronautServletMappings = new ArrayList<>();
+
+    @Inject
+    public MicronautServletInitializer(ApplicationContext applicationContext) {
+        this.applicationContext = applicationContext;
+    }
+
+    public MicronautServletInitializer() {
+    }
 
     @Override
     public void onStartup(Set<Class<?>> c, ServletContext ctx) {
-        final ApplicationContext applicationContext = buildApplicationContext(ctx)
+        final ApplicationContext applicationContext = this.applicationContext != null ? this.applicationContext : buildApplicationContext(ctx)
                 .build()
                 .start();
         final MicronautServletConfiguration configuration = applicationContext.getBean(MicronautServletConfiguration.class);
-        final ServletRegistration.Dynamic registration =
-                ctx.addServlet(configuration.getName(), new DefaultMicronautServlet(applicationContext));
+        Collection<BeanRegistration<Servlet>> servlets = applicationContext.getBeanRegistrations(Servlet.class);
+        Collection<BeanRegistration<Filter>> filters = applicationContext.getBeanRegistrations(Filter.class);
+        Collection<EventListener> servletListeners = applicationContext.getBeansOfType(EventListener.class, Qualifiers.byStereotype(WebListener.class));
+        int servletOrder = 0;
+        for (BeanRegistration<Servlet> servlet : servlets) {
+            Servlet servletBean = servlet.getBean();
+            String servletName = resolveName(servlet.getIdentifier(), servlet.getBeanDefinition());
+            ServletRegistration.Dynamic registration = ctx.addServlet(servletName, servletBean);
+            servletOrder = configureServletBean(
+                servlet,
+                servletName,
+                configuration,
+                servletOrder,
+                registration,
+                applicationContext
+            );
+        }
+        for (BeanRegistration<Filter> beanRegistration : filters) {
+            handleFilterRegistration(ctx, beanRegistration);
+        }
 
-        configuration.getMultipartConfigElement().ifPresent(registration::setMultipartConfig);
-        applicationContext.findBean(ServletSecurityElement.class)
+        for (EventListener servletListener : servletListeners) {
+            ctx.addListener(servletListener);
+        }
+
+    }
+
+    private static void handleFilterRegistration(ServletContext ctx, BeanRegistration<Filter> beanRegistration) {
+        Filter filter = beanRegistration.getBean();
+        BeanIdentifier identifier = beanRegistration.getIdentifier();
+        BeanDefinition<Filter> beanDefinition = beanRegistration.getBeanDefinition();
+        String filterName = resolveName(identifier, beanDefinition);
+        FilterRegistration.Dynamic registration = ctx.addFilter(filterName, filter);
+        AnnotationValue<WebFilter> webFilterAnn = beanDefinition.findAnnotation(WebFilter.class).orElse(new AnnotationValue<>(WebFilter.class.getName()));
+        DispatcherType[] dispatcherTypes = webFilterAnn.enumValues("dispatcherTypes", DispatcherType.class);
+        if (ArrayUtils.isEmpty(dispatcherTypes)) {
+            dispatcherTypes = DEFAULT_DISPATCHER_TYPES;
+        }
+
+        @NonNull String[] urlPatterns = ArrayUtils.concat(
+            webFilterAnn.stringValues(),
+            webFilterAnn.stringValues(MEMBER_URL_PATTERNS)
+        );
+        @NonNull String[] servletNames = webFilterAnn.stringValues("servletNames");
+        EnumSet<DispatcherType> enumSet;
+        if (dispatcherTypes.length > 1) {
+            enumSet = EnumSet.of(dispatcherTypes[0], Arrays.copyOfRange(dispatcherTypes, 1, dispatcherTypes.length));
+        } else {
+            enumSet = EnumSet.of(dispatcherTypes[0]);
+        }
+
+        if (ArrayUtils.isNotEmpty(urlPatterns)) {
+            registration.addMappingForUrlPatterns(
+                enumSet,
+                true,
+                urlPatterns
+            );
+        }
+        if (ArrayUtils.isNotEmpty(servletNames)) {
+            registration.addMappingForUrlPatterns(
+                enumSet,
+                true,
+                servletNames
+            );
+        }
+        setInitParams(webFilterAnn, registration);
+        registration.setAsyncSupported(webFilterAnn.booleanValue(MEMBER_ASYNC_SUPPORTED).orElse(false));
+    }
+
+    private static String resolveName(BeanIdentifier identifier, BeanDefinition<?> definition) {
+        String name = identifier.getName();
+        return name.equals("Primary") ? definition.getBeanType().getName() : name;
+    }
+
+    private int configureServletBean(BeanRegistration<Servlet> servlet, String servletName, MicronautServletConfiguration configuration, int order, ServletRegistration.Dynamic registration, ApplicationContext applicationContext) {
+        BeanDefinition<Servlet> beanDefinition = servlet.getBeanDefinition();
+        AnnotationValue<WebServlet> webServletAnnotationValue = beanDefinition
+            .findAnnotation(WebServlet.class)
+            .orElse(EMPTY_WEB_SERVLET);
+        boolean isMicronautServlet = DefaultMicronautServlet.NAME.equals(servletName);
+        @NonNull String[] urlPatterns = getUrlPatterns(webServletAnnotationValue, beanDefinition, isMicronautServlet, configuration);
+        int loadOnStartup = webServletAnnotationValue.intValue(MEMBER_LOAD_ON_STARTUP).orElse(order++);
+        boolean isAsyncSupported = webServletAnnotationValue.booleanValue(MEMBER_ASYNC_SUPPORTED).orElse(configuration.isAsyncSupported());
+
+        registration.addMapping(urlPatterns);
+        registration.setLoadOnStartup(loadOnStartup);
+        registration.setAsyncSupported(isAsyncSupported);
+        setInitParams(webServletAnnotationValue, registration);
+        MultipartConfigElement multipartConfigElement = getMultipartConfig(beanDefinition, isMicronautServlet, configuration);
+        if (multipartConfigElement != null) {
+            registration.setMultipartConfig(multipartConfigElement);
+        }
+        ServletSecurity servletSecurity = beanDefinition.synthesizeDeclared(ServletSecurity.class);
+        if (servletSecurity != null) {
+            registration.setServletSecurity(new ServletSecurityElement(servletSecurity));
+        } else if (isMicronautServlet) {
+            applicationContext.findBean(ServletSecurityElement.class)
                 .ifPresent(registration::setServletSecurity);
-        registration.setLoadOnStartup(1);
-        registration.setAsyncSupported(true);
-        registration.addMapping(configuration.getMapping());
+        }
+        return order;
+    }
+
+    private @NonNull String[] getUrlPatterns(AnnotationValue<WebServlet> webServletAnnotationValue, BeanDefinition<Servlet> beanDefinition, boolean isMicronautServlet, MicronautServletConfiguration configuration) {
+        @NonNull String[] urlPatterns =
+            ArrayUtils.concat(
+                webServletAnnotationValue.stringValues(),
+                beanDefinition.stringValues(MEMBER_URL_PATTERNS)
+            );
+        if (ArrayUtils.isEmpty(urlPatterns) && isMicronautServlet) {
+            urlPatterns = ArrayUtils.concat(micronautServletMappings.toArray(String[]::new), configuration.getMapping());
+        }
+        return urlPatterns;
+    }
+
+    private static void setInitParams(AnnotationValue<WebServlet> webServletAnnotationValue, ServletRegistration.Dynamic registration) {
+        webServletAnnotationValue.getAnnotations(MEMBER_INIT_PARAMS, WebInitParam.class).forEach(av -> {
+                av.stringValue("name").ifPresent(name ->
+                    av.stringValue().ifPresent(value ->
+                        registration.setInitParameter(name, value)
+                    )
+                );
+        });
+    }
+
+    private static void setInitParams(AnnotationValue<WebFilter> webFilter, FilterRegistration.Dynamic registration) {
+        webFilter.getAnnotations(MEMBER_INIT_PARAMS, WebInitParam.class).forEach(av -> {
+            av.stringValue("name").ifPresent(name ->
+                av.stringValue().ifPresent(value ->
+                    registration.setInitParameter(name, value)
+                )
+            );
+        });
+    }
+
+    private MultipartConfigElement getMultipartConfig(BeanDefinition<Servlet> beanDefinition, boolean isMicronautServlet, MicronautServletConfiguration configuration) {
+        return beanDefinition.findAnnotation(MultipartConfig.class)
+                .map(this::toMultipartElement)
+                .orElse(isMicronautServlet ? configuration.getMultipartConfigElement().orElse(null) : null);
+    }
+
+    private MultipartConfigElement toMultipartElement(AnnotationValue<MultipartConfig> annotation) {
+        String location = annotation.stringValue("location").orElse("");
+        long maxFileSize = annotation.longValue("maxFileSize").orElse(-1);
+        long maxRequestSize = annotation.longValue("maxRequestSize").orElse(-1);
+        int fileSizeThreshold = annotation.intValue("fileSizeThreshold").orElse(-1);
+        return new MultipartConfigElement(
+            location,
+            maxFileSize,
+            maxRequestSize,
+            fileSizeThreshold
+        );
     }
 
     /**
@@ -80,5 +266,15 @@ public class MicronautServletInitializer implements ServletContainerInitializer 
         }
 
         return contextBuilder;
+    }
+
+    /**
+     * Adds an additional mapping for the micronaut servlet.
+     * @param mapping The mapping.
+     */
+    public void addMicronautServletMapping(String mapping) {
+        if (StringUtils.isNotEmpty(mapping)) {
+            this.micronautServletMappings.add(mapping);
+        }
     }
 }

--- a/servlet-processor/build.gradle.kts
+++ b/servlet-processor/build.gradle.kts
@@ -1,0 +1,13 @@
+plugins {
+    id("io.micronaut.build.internal.servlet.module")
+}
+
+dependencies {
+    api(libs.managed.servlet.api)
+    implementation(mn.micronaut.core.processor)
+    testImplementation(mn.micronaut.inject.java.test)
+}
+
+micronautBuild {
+    binaryCompatibility.enabled.set(false)
+}

--- a/servlet-processor/src/main/java/io/micronaut/servlet/annotation/processor/ServletAnnotationVisitor.java
+++ b/servlet-processor/src/main/java/io/micronaut/servlet/annotation/processor/ServletAnnotationVisitor.java
@@ -1,0 +1,81 @@
+/*
+ * Copyright 2017-2024 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.servlet.annotation.processor;
+
+import static io.micronaut.core.util.ArrayUtils.concat;
+
+import io.micronaut.core.annotation.NonNull;
+import io.micronaut.core.util.ArrayUtils;
+import io.micronaut.inject.ast.ClassElement;
+import io.micronaut.inject.ast.MethodElement;
+import io.micronaut.inject.processing.ProcessingException;
+import io.micronaut.inject.visitor.TypeElementVisitor;
+import io.micronaut.inject.visitor.VisitorContext;
+import jakarta.servlet.Filter;
+import jakarta.servlet.Servlet;
+import jakarta.servlet.annotation.WebFilter;
+import jakarta.servlet.annotation.WebListener;
+import jakarta.servlet.annotation.WebServlet;
+import java.util.Set;
+
+public class ServletAnnotationVisitor implements TypeElementVisitor<Object, Object> {
+    @Override
+    public VisitorKind getVisitorKind() {
+        return VisitorKind.ISOLATING;
+    }
+
+    @Override
+    public Set<String> getSupportedAnnotationNames() {
+        return Set.of("jakarta.servlet.*");
+    }
+
+    @Override
+    public void visitClass(ClassElement element, VisitorContext context) {
+        if (element.hasDeclaredAnnotation(WebFilter.class) && !element.isAssignable(Filter.class)) {
+            throw new ProcessingException(element, "Types annotated with @WebFilter must implement jakarta.servlet.Filter");
+        }
+        if (element.hasDeclaredAnnotation(WebServlet.class) && !element.isAssignable(Servlet.class)) {
+            throw new ProcessingException(element, "Types annotated with @WebServlet must implement jakarta.servlet.Servlet");
+        }
+        if (element.hasDeclaredAnnotation(WebListener.class) && !element.isAssignable(java.util.EventListener.class)) {
+            throw new ProcessingException(element, "Types annotated with @WebListener must implement java.util.EventListener");
+        }
+
+        @NonNull String[] patterns = concat(concat(
+                element.stringValues(WebFilter.class),
+                element.stringValues(WebServlet.class, "urlPatterns")
+            ),
+            concat(
+                element.stringValues(WebServlet.class),
+                element.stringValues(WebServlet.class, "urlPatterns")
+            ));
+        for (String pattern : patterns) {
+            if (pattern.endsWith("/**") && pattern.length() > 3) {
+                throw new ProcessingException(element, "Servlet Spec 12.2 violation: glob '*' can only exist at end of prefix based matches: bad spec \"" + pattern + "\"");
+            }
+        }
+    }
+
+    @Override
+    public void visitMethod(MethodElement element, VisitorContext context) {
+        if (element.hasDeclaredAnnotation(WebFilter.class) && !element.getGenericReturnType().isAssignable(Filter.class)) {
+            throw new ProcessingException(element, "Methods annotated with @ServletFilterBean must implement jakarta.servlet.Filter");
+        }
+        if (element.hasDeclaredAnnotation(WebServlet.class) && !element.getGenericReturnType().isAssignable(Servlet.class)) {
+            throw new ProcessingException(element, "Methods annotated with @ServletBean must implement jakarta.servlet.Servlet");
+        }
+    }
+}

--- a/servlet-processor/src/main/java/io/micronaut/servlet/annotation/processor/WebFilterMapper.java
+++ b/servlet-processor/src/main/java/io/micronaut/servlet/annotation/processor/WebFilterMapper.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2017-2024 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.servlet.annotation.processor;
+
+import io.micronaut.core.annotation.AnnotationValue;
+import io.micronaut.core.util.StringUtils;
+import io.micronaut.inject.annotation.TypedAnnotationMapper;
+import io.micronaut.inject.visitor.VisitorContext;
+import jakarta.inject.Named;
+import jakarta.inject.Singleton;
+import jakarta.servlet.annotation.WebFilter;
+import java.util.List;
+
+/**
+ * Allows registering web filters as beans.
+ */
+public class WebFilterMapper implements TypedAnnotationMapper<WebFilter> {
+    @Override
+    public Class<WebFilter> annotationType() {
+        return WebFilter.class;
+    }
+
+    @Override
+    public List<AnnotationValue<?>> map(AnnotationValue<WebFilter> annotation, VisitorContext visitorContext) {
+        String name = annotation.stringValue("filterName").orElse(null);
+        if (StringUtils.isNotEmpty(name)) {
+            return List.of(
+                AnnotationValue.builder(Named.class).value(name).build(),
+                AnnotationValue.builder(Singleton.class).build()
+            );
+        } else {
+            return List.of(AnnotationValue.builder(Singleton.class).build());
+        }
+    }
+}

--- a/servlet-processor/src/main/java/io/micronaut/servlet/annotation/processor/WebListenerMapper.java
+++ b/servlet-processor/src/main/java/io/micronaut/servlet/annotation/processor/WebListenerMapper.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2017-2024 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.servlet.annotation.processor;
+
+import io.micronaut.context.annotation.Bean;
+import io.micronaut.core.annotation.AnnotationValue;
+import io.micronaut.inject.annotation.TypedAnnotationMapper;
+import io.micronaut.inject.visitor.VisitorContext;
+import jakarta.servlet.annotation.WebListener;
+import java.util.List;
+
+/**
+ * Allows registering web listeners as beans.
+ */
+public class WebListenerMapper implements TypedAnnotationMapper<WebListener> {
+    @Override
+    public Class<WebListener> annotationType() {
+        return WebListener.class;
+    }
+
+    @Override
+    public List<AnnotationValue<?>> map(AnnotationValue<WebListener> annotation, VisitorContext visitorContext) {
+        return List.of(AnnotationValue.builder(Bean.class).build());
+    }
+}

--- a/servlet-processor/src/main/java/io/micronaut/servlet/annotation/processor/WebServletMapper.java
+++ b/servlet-processor/src/main/java/io/micronaut/servlet/annotation/processor/WebServletMapper.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2017-2024 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.servlet.annotation.processor;
+
+import io.micronaut.core.annotation.AnnotationValue;
+import io.micronaut.core.util.StringUtils;
+import io.micronaut.inject.annotation.TypedAnnotationMapper;
+import io.micronaut.inject.visitor.VisitorContext;
+import jakarta.inject.Named;
+import jakarta.inject.Singleton;
+import jakarta.servlet.annotation.WebServlet;
+import java.util.List;
+
+/**
+ * Allows registering web servlets as beans.
+ */
+public class WebServletMapper implements TypedAnnotationMapper<WebServlet> {
+    @Override
+    public Class<WebServlet> annotationType() {
+        return WebServlet.class;
+    }
+
+    @Override
+    public List<AnnotationValue<?>> map(AnnotationValue<WebServlet> annotation, VisitorContext visitorContext) {
+        String name = annotation.stringValue("name").orElse(null);
+        if (StringUtils.isNotEmpty(name)) {
+            return List.of(
+                AnnotationValue.builder(Named.class).value(name).build(),
+                AnnotationValue.builder(Singleton.class).build()
+            );
+        } else {
+            return List.of(AnnotationValue.builder(Singleton.class).build());
+        }
+    }
+}

--- a/servlet-processor/src/main/resources/META-INF/services/io.micronaut.inject.annotation.AnnotationMapper
+++ b/servlet-processor/src/main/resources/META-INF/services/io.micronaut.inject.annotation.AnnotationMapper
@@ -1,0 +1,3 @@
+io.micronaut.servlet.annotation.processor.WebFilterMapper
+io.micronaut.servlet.annotation.processor.WebListenerMapper
+io.micronaut.servlet.annotation.processor.WebServletMapper

--- a/servlet-processor/src/main/resources/META-INF/services/io.micronaut.inject.visitor.TypeElementVisitor
+++ b/servlet-processor/src/main/resources/META-INF/services/io.micronaut.inject.visitor.TypeElementVisitor
@@ -1,0 +1,1 @@
+io.micronaut.servlet.annotation.processor.ServletAnnotationVisitor

--- a/servlet-processor/src/main/resources/logback.xml
+++ b/servlet-processor/src/main/resources/logback.xml
@@ -1,0 +1,19 @@
+<configuration>
+
+    <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+        <!-- encoders are assigned the type
+             ch.qos.logback.classic.encoder.PatternLayoutEncoder by default -->
+        <encoder>
+            <pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n</pattern>
+        </encoder>
+    </appender>
+
+    <root level="info">
+        <appender-ref ref="STDOUT" />
+    </root>
+    <!-- <logger name="io.micronaut.http" level="TRACE"/> -->
+    <!-- <logger name="io.micronaut.web.router" level="TRACE"/> -->
+    <!--<logger name="io.micronaut.websocket" level="TRACE"/>-->
+    <!--<logger name="io.netty" level="TRACE"/>-->
+
+</configuration>

--- a/servlet-processor/src/test/groovy/io/micronaut/servlet/annotation/processor/ServletAnnotationSpec.groovy
+++ b/servlet-processor/src/test/groovy/io/micronaut/servlet/annotation/processor/ServletAnnotationSpec.groovy
@@ -1,0 +1,73 @@
+package io.micronaut.servlet.annotation.processor
+
+import io.micronaut.annotation.processing.test.AbstractTypeElementSpec
+import io.micronaut.context.ApplicationContext
+import io.micronaut.inject.qualifiers.Qualifiers
+import jakarta.servlet.Servlet
+
+class ServletAnnotationSpec
+        extends AbstractTypeElementSpec {
+
+    void "test servlet annotated is bean"() {
+        given:
+        def context = buildContext('''
+package test;
+
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.GenericFilter;
+import jakarta.servlet.GenericServlet;
+import jakarta.servlet.ServletContextEvent;
+import jakarta.servlet.ServletContextListener;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.ServletRequest;
+import jakarta.servlet.ServletResponse;
+import jakarta.servlet.annotation.WebFilter;
+import jakarta.servlet.annotation.WebListener;
+import jakarta.servlet.annotation.WebServlet;
+import java.io.*;
+
+@WebServlet
+class MyServlet extends GenericServlet {
+    @Override
+    public void service(ServletRequest req, ServletResponse res)
+        throws ServletException, IOException {
+
+    }
+}
+
+@WebServlet(name = "test")
+class MyServlet2 extends GenericServlet {
+@Override
+    public void service(ServletRequest req, ServletResponse res)
+        throws ServletException, IOException {
+
+    }
+}
+
+@WebFilter
+class Filter1 extends GenericFilter {
+    @Override public void doFilter(ServletRequest request, ServletResponse response, FilterChain chain)
+        throws IOException, ServletException {
+    }
+}
+@WebFilter(filterName = "two")
+class Filter2 extends GenericFilter {
+    @Override public void doFilter(ServletRequest request, ServletResponse response, FilterChain chain)
+        throws IOException, ServletException {
+    }
+}
+
+@WebListener
+class Listener implements ServletContextListener {
+}
+''')
+        expect:
+        getBean(context, 'test.MyServlet')
+        getBean(context, 'test.MyServlet2')
+        getBean(context, 'test.MyServlet', Qualifiers.byName("MyServlet"))
+        getBean(context, 'test.MyServlet2', Qualifiers.byName("test"))
+        getBean(context, 'test.Listener')
+        getBean(context, 'test.Filter1')
+        getBean(context, 'test.Filter2')
+    }
+}

--- a/settings.gradle
+++ b/settings.gradle
@@ -24,6 +24,7 @@ micronautBuild {
 }
 
 include 'servlet-bom'
+include 'servlet-processor'
 include 'servlet-core'
 include 'servlet-engine'
 include 'http-server-jetty'

--- a/src/main/docs/guide/servletAnnotation.adoc
+++ b/src/main/docs/guide/servletAnnotation.adoc
@@ -1,0 +1,7 @@
+The following annotations can be used from the Servlet API to add additional servlets, filters and listeners as beans:
+
+* `jakarta.servlet.annotation.WebFilter` - Applicable to types that implement the `jakarta.servlet.Filter` interface.
+* `jakarta.servlet.annotation.WebServlet` - Applicable to types that implement the `jakarta.servlet.Servlet` interface.
+* `jakarta.servlet.annotation.WebListener` - See the annotation javadoc for applicable types.
+
+The `io.micronaut.core.annotation.Order` annotation can be used to control registration order and hence filter order. For example A value of `io.micronaut.core.order.Ordered.HIGHEST_PRECEDENCE` will run the filter first.

--- a/src/main/docs/guide/servletAnnotation.adoc
+++ b/src/main/docs/guide/servletAnnotation.adoc
@@ -1,7 +1,16 @@
-The following annotations can be used from the Servlet API to add additional servlets, filters and listeners as beans:
+To use the Servlet APIs annotations to register servlets, filters and listeners you first need to add the following annotation processor dependency:
+
+dependency:io.micronaut.servlet:micronaut-servlet-processor[scope="annotationProcessor"]
+
+The following annotations can then be used from the Servlet API to add additional servlets, filters and listeners as beans:
 
 * `jakarta.servlet.annotation.WebFilter` - Applicable to types that implement the `jakarta.servlet.Filter` interface.
 * `jakarta.servlet.annotation.WebServlet` - Applicable to types that implement the `jakarta.servlet.Servlet` interface.
 * `jakarta.servlet.annotation.WebListener` - See the annotation javadoc for applicable types.
 
 The `io.micronaut.core.annotation.Order` annotation can be used to control registration order and hence filter order. For example A value of `io.micronaut.core.order.Ordered.HIGHEST_PRECEDENCE` will run the filter first.
+
+In addition you can use the following annotations on methods of `@Factory` beans to instantiate servlets and filters and register them:
+
+* ann:servlet.engine.annotation.ServletBean[] - Register a new servlet via a factory method
+* ann:servlet.engine.annotation.ServletFilterBean[] - Register a new filter via a factory method

--- a/src/main/docs/guide/servletAnnotation.adoc
+++ b/src/main/docs/guide/servletAnnotation.adoc
@@ -1,16 +1,18 @@
-To use the Servlet APIs annotations to register servlets, filters and listeners you first need to add the following annotation processor dependency:
+To use the https://jakarta.ee/specifications/servlet/5.0/apidocs/jakarta/servlet/annotation/package-summary[Servlet APIs annotations] to register servlets, filters and listeners you first need to add the following annotation processor dependency:
 
 dependency:io.micronaut.servlet:micronaut-servlet-processor[scope="annotationProcessor"]
 
 The following annotations can then be used from the Servlet API to add additional servlets, filters and listeners as beans:
 
-* `jakarta.servlet.annotation.WebFilter` - Applicable to types that implement the `jakarta.servlet.Filter` interface.
-* `jakarta.servlet.annotation.WebServlet` - Applicable to types that implement the `jakarta.servlet.Servlet` interface.
-* `jakarta.servlet.annotation.WebListener` - See the annotation javadoc for applicable types.
+* https://jakarta.ee/specifications/servlet/5.0/apidocs/jakarta/servlet/annotation/webfilter[@WebFilter] - Applicable to types that implement the `jakarta.servlet.Filter` interface.
+* https://jakarta.ee/specifications/servlet/5.0/apidocs/jakarta/servlet/annotation/webservlet[@WebServlet] - Applicable to types that implement the `jakarta.servlet.Servlet` interface.
+* https://jakarta.ee/specifications/servlet/5.0/apidocs/jakarta/servlet/annotation/weblistener[@WebListener] - See the annotation javadoc for applicable types.
 
-The `io.micronaut.core.annotation.Order` annotation can be used to control registration order and hence filter order. For example A value of `io.micronaut.core.order.Ordered.HIGHEST_PRECEDENCE` will run the filter first.
+The https://docs.micronaut.io/latest/api/io/micronaut/core/annotation/Order.html[@Order] annotation can be used to control registration order and hence filter order. For example a value of https://docs.micronaut.io/latest/api/io/micronaut/core/order/Ordered.html#HIGHEST_PRECEDENCE[io.micronaut.core.order.Ordered.HIGHEST_PRECEDENCE] will run the filter first.
 
-In addition you can use the following annotations on methods of `@Factory` beans to instantiate servlets and filters and register them:
+NOTE: Using `HIGHEST_PRECEDENCE` will prevent any other filter running before your filter. The default position is `0` and `HIGHEST_PRECEDENCE` == `Integer.MIN_VALUE` hence you should consider using constants to the represent the position of your filter that exist somewhere between `HIGHEST_PRECEDENCE` and `LOWEST_PRECEDENCE`.
 
-* ann:servlet.engine.annotation.ServletBean[] - Register a new servlet via a factory method
-* ann:servlet.engine.annotation.ServletFilterBean[] - Register a new filter via a factory method
+In addition, you can use the following annotations on methods of https://docs.micronaut.io/latest/guide/#factories[@Factory beans] to instantiate servlets and filters and register them:
+
+* ann:servlet.engine.annotation.ServletBean[] - Equivalent of https://jakarta.ee/specifications/servlet/5.0/apidocs/jakarta/servlet/annotation/webservlet[@WebServlet] but can be applied to a method of a factory to Register a new servlet.
+* ann:servlet.engine.annotation.ServletFilterBean[] - Equivalent of https://jakarta.ee/specifications/servlet/5.0/apidocs/jakarta/servlet/annotation/webfilter[@WebFilter] but can be applied to a method of a factory to Register a new filter.

--- a/src/main/docs/guide/toc.yml
+++ b/src/main/docs/guide/toc.yml
@@ -1,6 +1,7 @@
 introduction: Introduction
 releaseHistory: Release History
 servletApi: Working with the Servlet API
+servletAnnotation: Servlet Annotation Support
 warDeployment:
   title: WAR Deployment
   versioning: Container version considerations


### PR DESCRIPTION
* Allows the DefaultMicronautServlet to be replaced / customized
* Adds support for Servlet annotation model (`@WebServlet`, `@WebFilter` and `@WebListener`)
* Unifies the logic across implementations to use MicronautServletInitialier
* Correctly implement dual-protocol setting
* Fix random port binding
