### PR TITLE
Fix reactive error handling during write

### DIFF
--- a/servlet-core/src/main/java/io/micronaut/servlet/http/body/AvailableByteArrayBody.java
+++ b/servlet-core/src/main/java/io/micronaut/servlet/http/body/AvailableByteArrayBody.java
@@ -28,7 +28,7 @@ import java.util.concurrent.CompletableFuture;
 /**
  * {@link io.micronaut.http.body.AvailableByteBody} implementation based on a byte array.
  * <p>
- * Note: While internal, this is also used from the AWS and GCP modules.
+ * Note: While internal, this is also used from the Azure, AWS and GCP modules.
  *
  * @author Jonas Konrad
  * @since 4.9.0

--- a/servlet-core/src/main/java/io/micronaut/servlet/http/body/InputStreamByteBody.java
+++ b/servlet-core/src/main/java/io/micronaut/servlet/http/body/InputStreamByteBody.java
@@ -36,6 +36,8 @@ import java.util.concurrent.Executor;
 
 /**
  * Streaming {@link io.micronaut.http.body.ByteBody} implementation for servlet.
+ * <p>
+ * Note: While internal, this is also used from the Azure, AWS and GCP modules.
  *
  * @since 4.9.0
  * @author Jonas Konrad


### PR DESCRIPTION
In the gcp module, it is not permitted to set HTTP headers/status after getInputStream is called. This becomes a problem when returning Flux.error from a controller, because the previous code would call getInputStream (and write a json array start) before the error is seen.

This change delays calling getInputStream until after the first element is taken from the reactive stream.

Also adjusted the comment on AvailableByteArrayBody and InputStreamByteBody.