### PR TITLE
Cover an edge case for streams where the original stream is closed

### DIFF
--- a/servlet-core/src/main/java/io/micronaut/servlet/http/body/StreamPair.java
+++ b/servlet-core/src/main/java/io/micronaut/servlet/http/body/StreamPair.java
@@ -243,8 +243,12 @@ final class StreamPair {
                 if (!queue.isEmpty() && fastModeSlowerSide == left) {
                     return queue.take(b, off, len);
                 } else {
+                    if (singleSideComplete) {
+                        return -1;
+                    }
                     int n = upstream.read(b, off, len);
                     if (n == -1) {
+                        singleSideComplete = true;
                         return -1;
                     }
                     if (!isOtherSideCancelled()) {


### PR DESCRIPTION
When all the data was already read from the original stream, no error should be produced, as all the data was stored in the queue.