### PR TITLE
don’t exclude JsonViewTest

### DIFF
--- a/test-suite-http-server-tck-jetty/src/test/java/io/micronaut/http/server/tck/jetty/tests/JettyHttpServerTestSuite.java
+++ b/test-suite-http-server-tck-jetty/src/test/java/io/micronaut/http/server/tck/jetty/tests/JettyHttpServerTestSuite.java
@@ -16,7 +16,6 @@ import org.junit.platform.suite.api.SuiteDisplayName;
     "io.micronaut.http.server.tck.tests.filter.ClientResponseFilterTest", // responseFilterThrowableParameter fails under Graal https://ge.micronaut.io/s/ufuhtbe5sgmxi
     "io.micronaut.http.server.tck.tests.FilterProxyTest", // see https://github.com/micronaut-projects/micronaut-core/issues/9725
     "io.micronaut.http.server.tck.tests.LocalErrorReadingBodyTest", // Cannot read body as text once stream is exhausted trying to read it as a different type See https://github.com/micronaut-projects/micronaut-servlet/pull/548
-    "io.micronaut.http.server.tck.tests.jsonview.JsonViewsTest", // Not serdeable
 })
 public class JettyHttpServerTestSuite {
 }

--- a/test-suite-http-server-tck-poja-apache/src/test/java/io/micronaut/http/server/tck/poja/PojaApacheServerTestSuite.java
+++ b/test-suite-http-server-tck-poja-apache/src/test/java/io/micronaut/http/server/tck/poja/PojaApacheServerTestSuite.java
@@ -36,7 +36,6 @@ import org.junit.platform.suite.api.SuiteDisplayName;
     "io.micronaut.http.server.tck.tests.constraintshandler.ControllerConstraintHandlerTest",
     // Proxying is probably not supported. There is no request concurrency
     "io.micronaut.http.server.tck.tests.FilterProxyTest",
-    "io.micronaut.http.server.tck.tests.jsonview.JsonViewsTest", // Not serdeable
 })
 public class PojaApacheServerTestSuite {
 }

--- a/test-suite-http-server-tck-tomcat/src/test/java/io/micronaut/http/server/tck/tomcat/tests/TomcatHttpServerTestSuite.java
+++ b/test-suite-http-server-tck-tomcat/src/test/java/io/micronaut/http/server/tck/tomcat/tests/TomcatHttpServerTestSuite.java
@@ -13,7 +13,6 @@ import org.junit.platform.suite.api.SuiteDisplayName;
     "io.micronaut.http.server.tck.tests.filter.ClientResponseFilterTest", // responseFilterThrowableParameter fails under Graal https://ge.micronaut.io/s/ufuhtbe5sgmxi
     "io.micronaut.http.server.tck.tests.FilterProxyTest", // see https://github.com/micronaut-projects/micronaut-core/issues/9725
     "io.micronaut.http.server.tck.tests.LocalErrorReadingBodyTest", // Cannot read body as text once stream is exhausted trying to read it as a different type See https://github.com/micronaut-projects/micronaut-servlet/pull/548
-    "io.micronaut.http.server.tck.tests.jsonview.JsonViewsTest", // Not serdeable
 })
 public class TomcatHttpServerTestSuite {
 }

--- a/test-suite-http-server-tck-undertow/src/test/java/io/micronaut/http/server/tck/undertow/tests/UndertowHttpServerTestSuite.java
+++ b/test-suite-http-server-tck-undertow/src/test/java/io/micronaut/http/server/tck/undertow/tests/UndertowHttpServerTestSuite.java
@@ -15,7 +15,6 @@ import org.junit.platform.suite.api.SuiteDisplayName;
     "io.micronaut.http.server.tck.tests.StreamTest", // The outputstream in Undertow is marked ready asynchronously, and we throw the error early, so sometimes there's no body for statusErrorAsFirstItem.
     "io.micronaut.http.server.tck.tests.FilterProxyTest", // see https://github.com/micronaut-projects/micronaut-core/issues/9725
     "io.micronaut.http.server.tck.tests.LocalErrorReadingBodyTest", // Cannot read body as text once stream is exhausted trying to read it as a different type See https://github.com/micronaut-projects/micronaut-servlet/pull/548
-    "io.micronaut.http.server.tck.tests.jsonview.JsonViewsTest", // Not serdeable
 })
 public class UndertowHttpServerTestSuite {
 }


### PR DESCRIPTION
`JsonViewsTest::testJsonViewFlux` fails: 

```
Expected received body of '[{"id":1,"name":"Joe","password":"secret"}]' to doesnt_contain 'password'
Expected :true
Actual   :false
<Click to see difference>

org.opentest4j.AssertionFailedError: Expected received body of '[{"id":1,"name":"Joe","password":"secret"}]' to doesnt_contain 'password' ==> expected: <true> but was: <false>
	at org.junit.jupiter.api.AssertionFailureBuilder.build(AssertionFailureBuilder.java:151)
	at org.junit.jupiter.api.AssertionFailureBuilder.buildAndThrow(AssertionFailureBuilder.java:132)
	at org.junit.jupiter.api.AssertTrue.failNotTrue(AssertTrue.java:63)
	at org.junit.jupiter.api.AssertTrue.assertTrue(AssertTrue.java:42)
	at org.junit.jupiter.api.Assertions.assertTrue(Assertions.java:191)
	at io.micronaut.http.tck.BodyAssertion.evaluate(BodyAssertion.java:84)
	at io.micronaut.http.tck.AssertionUtils.assertBody(AssertionUtils.java:128)
	at io.micronaut.http.tck.AssertionUtils.assertDoesNotThrow(AssertionUtils.java:120)
	at io.micronaut.http.server.tck.tests.jsonview.JsonViewsTest.lambda$assertPath$0(JsonViewsTest.java:75)
	at io.micronaut.http.tck.TestScenario.run(TestScenario.java:118)
	at io.micronaut.http.tck.TestScenario$Builder.run(TestScenario.java:201)
	at io.micronaut.http.tck.TestScenario.asserts(TestScenario.java:67)
	at io.micronaut.http.server.tck.tests.jsonview.JsonViewsTest.assertPath(JsonViewsTest.java:72)
	at io.micronaut.http.server.tck.tests.jsonview.JsonViewsTest.testJsonViewFlux(JsonViewsTest.java:63)
	at java.base/java.lang.reflect.Method.invoke(Method.java:580)
	at java.base/java.util.ArrayList.forEach(ArrayList.java:1596)
	at java.base/java.util.ArrayList.forEach(ArrayList.java:1596)
```

@yawkat 

> the flux test fails because [it still hits this code which doesnt use the messagebodywriter](https://github.com/micronaut-projects/micronaut-servlet/blob/6a915e7b6bdea77cd14901c21ea7d1d7b3ce10e3/servlet-engine/src/main/java/io/micronaut/servlet/engine/DefaultServletHttpResponse.java#L176)