### PR TITLE
improve error for misconfigured static resources in Jetty

### DIFF
--- a/http-server-jetty/src/main/java/io/micronaut/servlet/jetty/JettyFactory.java
+++ b/http-server-jetty/src/main/java/io/micronaut/servlet/jetty/JettyFactory.java
@@ -375,16 +375,21 @@ public class JettyFactory extends ServletServerFactory {
         ResourceHandler resourceHandler = new ResourceHandler();
         Resource[] resourceArray = config.getPaths().stream()
             .map(path -> {
+                Resource resource;
                 if (path.startsWith(ServletStaticResourceConfiguration.CLASSPATH_PREFIX)) {
                     String cp = path.substring(ServletStaticResourceConfiguration.CLASSPATH_PREFIX.length());
-                    return resourceFactory.newClassLoaderResource(cp);
+                    resource = resourceFactory.newClassLoaderResource(cp);
                 } else {
                     try {
-                        return resourceFactory.newResource(path);
+                        resource = resourceFactory.newResource(path);
                     } catch (Exception e) {
                         throw new ConfigurationException("Static resource path doesn't exist: " + path, e);
                     }
                 }
+                if (resource == null || !resource.exists()) {
+                    throw new ConfigurationException("Static resource path doesn't exist: " + path);
+                }
+                return resource;
             }).toArray(Resource[]::new);
 
         String path = config.getMapping();


### PR DESCRIPTION
If a resource references points to a resource that doesn't exist this results in the NPE below. This change checks the resource actually exists and throws an exception for the misconfigured resource it if doesn't exist.

```
Caused by: java.lang.NullPointerException
	at java.base/java.util.Objects.requireNonNull(Objects.java:208)
	at java.base/java.util.ImmutableCollections$List12.<init>(ImmutableCollections.java:556)
	at java.base/java.util.List.of(List.java:1043)
	at org.eclipse.jetty.util.resource.ResourceFactory.combine(ResourceFactory.java:152)
	at io.micronaut.servlet.jetty.JettyFactory.toHandler(JettyFactory.java:397)
	at io.micronaut.servlet.jetty.JettyFactory.lambda$configureServletInitializer$3(JettyFactory.java:298)
```