### PR TITLE
Use right port for the getServerAddress()

### DIFF
--- a/servlet-engine/src/main/java/io/micronaut/servlet/engine/DefaultServletHttpRequest.java
+++ b/servlet-engine/src/main/java/io/micronaut/servlet/engine/DefaultServletHttpRequest.java
@@ -312,7 +312,7 @@ public final class DefaultServletHttpRequest<B> implements
     @Override
     public InetSocketAddress getServerAddress() {
         return new InetSocketAddress(
-           delegate().getServerPort()
+           delegate().getLocalPort()
         );
     }
 


### PR DESCRIPTION

In the getServerAddress() use getLocalPort() instead of getServerPort() since the local port will always contain the right port and server port contains the port that client is facing.

For an example if there is a micronaut service running on 8443 and lb before it on 443:
- getLocalPort() returns 8443
- getServerPort() returns 443