### PR TITLE
don’t throw null pointer exception

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,6 +1,6 @@
 [versions]
 micronaut = "4.10.6"
-micronaut-docs = "2.0.0"
+micronaut-docs = "3.0.0"
 micronaut-test = "4.9.0"
 
 groovy = "4.0.27"

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -22,7 +22,7 @@ micronaut-validation = "4.11.0"
 google-cloud-functions = '1.1.4'
 micronaut-logging = "1.7.1"
 # Micronaut
-micronaut-gradle-plugin = "4.5.5"
+micronaut-gradle-plugin = "4.6.0"
 logback-access = "2.0.6"
 kotlin = "1.9.25"
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,5 +1,5 @@
 [versions]
-micronaut = "4.10.3"
+micronaut = "4.10.5"
 micronaut-docs = "2.0.0"
 micronaut-test = "4.9.0"
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,5 +1,5 @@
 [versions]
-micronaut = "4.10.5"
+micronaut = "4.10.6"
 micronaut-docs = "2.0.0"
 micronaut-test = "4.9.0"
 

--- a/servlet-engine/src/main/java/io/micronaut/servlet/engine/DefaultServletHttpRequest.java
+++ b/servlet-engine/src/main/java/io/micronaut/servlet/engine/DefaultServletHttpRequest.java
@@ -548,6 +548,9 @@ public final class DefaultServletHttpRequest<B> implements
             final String[] values = delegate.getParameterValues(
                 Objects.requireNonNull(name, "Parameter name cannot be null").toString()
             );
+            if (values == null) {
+                return Collections.emptyList();
+            }
             return Arrays.asList(values);
         }
 


### PR DESCRIPTION
`ServletRequest::getParameterValues` javadoc:

> Returns an array of String objects containing all of the values the given request parameter has, or **null** if the parameter does not exist.