### PR TITLE
Fix POJA to return running

### DIFF
--- a/http-poja-apache/src/test/groovy/io/micronaut/http/poja/EmbeddedServerSpec.groovy
+++ b/http-poja-apache/src/test/groovy/io/micronaut/http/poja/EmbeddedServerSpec.groovy
@@ -1,0 +1,23 @@
+package io.micronaut.http.poja
+
+
+import io.micronaut.runtime.EmbeddedApplication
+import io.micronaut.test.extensions.spock.annotation.MicronautTest
+import jakarta.inject.Inject
+import spock.lang.Specification
+
+@MicronautTest
+class EmbeddedServerSpec extends Specification {
+
+    @Inject
+    EmbeddedApplication<?> application
+
+    void "test server is running"() {
+        when:
+        true
+
+        then:
+        application.isRunning()
+    }
+
+}

--- a/http-poja-test/src/main/java/io/micronaut/http/poja/test/TestingServerlessEmbeddedApplication.java
+++ b/http-poja-test/src/main/java/io/micronaut/http/poja/test/TestingServerlessEmbeddedApplication.java
@@ -78,7 +78,7 @@ public class TestingServerlessEmbeddedApplication implements EmbeddedServer {
 
     @Override
     public TestingServerlessEmbeddedApplication start() {
-        if (isRunning.compareAndSet(true, true)) {
+        if (isRunning.getAndSet(true)) {
             return this; // Already running
         }
         createServerSocket();


### PR DESCRIPTION
This fixes an issue that appears when generating an application with micronaut launcher and running tests:
```
[ERROR] Tests run: 1, Failures: 1, Errors: 0, Skipped: 0, Time elapsed: 0.227 s <<< FAILURE! -- in com.example.DemoTest
[ERROR] com.example.DemoTest.testItWorks -- Time elapsed: 0.011 s <<< FAILURE!
org.opentest4j.AssertionFailedError: expected: <true> but was: <false>
        at org.junit.jupiter.api.AssertionFailureBuilder.build(AssertionFailureBuilder.java:151)
        at org.junit.jupiter.api.AssertionFailureBuilder.buildAndThrow(AssertionFailureBuilder.java:132)
        at org.junit.jupiter.api.AssertTrue.failNotTrue(AssertTrue.java:63)
        at org.junit.jupiter.api.AssertTrue.assertTrue(AssertTrue.java:36)
        at org.junit.jupiter.api.AssertTrue.assertTrue(AssertTrue.java:31)
        at org.junit.jupiter.api.Assertions.assertTrue(Assertions.java:183)
        at com.example.DemoTest.testItWorks(DemoTest.java:18)
        at java.base/java.lang.reflect.Method.invoke(Method.java:580)
        at io.micronaut.test.extensions.junit5.MicronautJunit5Extension$2.proceed(MicronautJunit5Extension.java:154)
        at io.micronaut.test.extensions.AbstractMicronautExtension.interceptEach(AbstractMicronautExtension.java:171)
        at io.micronaut.test.extensions.AbstractMicronautExtension.interceptTest(AbstractMicronautExtension.java:128)
        at io.micronaut.test.extensions.junit5.MicronautJunit5Extension.interceptTestMethod(MicronautJunit5Extension.java:141)
        at java.base/java.util.ArrayList.forEach(ArrayList.java:1597)
        at java.base/java.util.ArrayList.forEach(ArrayList.java:1597)
```

The application and other tests worked correctly. The only issue is that embedded application returned isRunning = false because the flag was not flipped correctly.