### PR TITLE
Fix Jetty static resource CORS allowed origins

### DIFF
--- a/http-server-jetty/src/main/java/io/micronaut/servlet/jetty/JettyFactory.java
+++ b/http-server-jetty/src/main/java/io/micronaut/servlet/jetty/JettyFactory.java
@@ -526,7 +526,7 @@ public class JettyFactory extends ServletServerFactory {
             }
             var origins = c.getAllowedOrigins();
             if (origins != null && !origins.isEmpty()) {
-                origins.forEach(JettyFactory::getOriginPattern);
+                origins.forEach(origin -> originPatterns.add(getOriginPattern(origin)));
             }
         }
         if (preflight != null) {

--- a/http-server-jetty/src/test/groovy/io/micronaut/servlet/jetty/JettyStaticResourceResolutionSpec.groovy
+++ b/http-server-jetty/src/test/groovy/io/micronaut/servlet/jetty/JettyStaticResourceResolutionSpec.groovy
@@ -30,9 +30,11 @@ import java.nio.file.Paths
 import java.util.concurrent.BlockingQueue
 import java.util.concurrent.LinkedBlockingQueue
 
+import static io.micronaut.http.HttpHeaders.ACCESS_CONTROL_ALLOW_ORIGIN
 import static io.micronaut.http.HttpHeaders.CACHE_CONTROL
 import static io.micronaut.http.HttpHeaders.CONTENT_LENGTH
 import static io.micronaut.http.HttpHeaders.CONTENT_TYPE
+import static io.micronaut.http.HttpHeaders.ORIGIN
 
 @MicronautTest
 class JettyStaticResourceResolutionSpec extends Specification implements TestPropertyProvider {
@@ -151,6 +153,38 @@ class JettyStaticResourceResolutionSpec extends Specification implements TestPro
         response.headers.contains(CACHE_CONTROL)
 
         response.body() == "<html><head></head><body>HTML Page from resources</body></html>"
+
+        cleanup:
+        rxClient.close()
+        embeddedServer.stop()
+    }
+
+    void "test cors for static resources uses configured allowed origins"() {
+        given:
+        EmbeddedServer embeddedServer = ApplicationContext.run(EmbeddedServer, [
+                'micronaut.router.static-resources.default.paths': ['classpath:public'],
+                'micronaut.router.static-resources.default.mapping': '/static/**',
+                'micronaut.server.cors.enabled': true,
+                'micronaut.server.cors.configurations.foo.allowedOrigins': ['foo.com']])
+        HttpClient rxClient = embeddedServer.applicationContext.createBean(HttpClient, embeddedServer.getURL())
+
+        when:
+        def allowedResponse = rxClient.toBlocking().exchange(
+                HttpRequest.GET("/static/index.html").header(ORIGIN, 'http://foo.com'), String
+        )
+
+        then:
+        allowedResponse.status == HttpStatus.OK
+        allowedResponse.header(ACCESS_CONTROL_ALLOW_ORIGIN) == 'http://foo.com'
+
+        when:
+        def forbiddenResponse = rxClient.toBlocking().exchange(
+                HttpRequest.GET("/static/index.html").header(ORIGIN, 'http://bar.com'), String
+        )
+
+        then:
+        forbiddenResponse.status == HttpStatus.OK
+        forbiddenResponse.header(ACCESS_CONTROL_ALLOW_ORIGIN) == null
 
         cleanup:
         rxClient.close()


### PR DESCRIPTION
The Jetty CORS adapter converted configured allowedOrigins to origin patterns, but did not add the converted values to the originPatterns set. That caused static resource CORS handling to fall back to .* instead of respecting configured origins.

Add the converted origins to the pattern set and cover the behavior with a static resource CORS regression test.

Bug introduced in https://github.com/micronaut-projects/micronaut-servlet/pull/1026 that was added to fix CorsStaticResourceTest