### PR TITLE
Fix WAR servlet server lifecycle events

### DIFF
--- a/servlet-engine/build.gradle.kts
+++ b/servlet-engine/build.gradle.kts
@@ -14,4 +14,5 @@ dependencies {
     implementation(mn.micronaut.jackson.core)
 
     testAnnotationProcessor(mn.micronaut.inject.java)
+    testImplementation(libs.junit.jupiter.engine)
 }

--- a/servlet-engine/src/main/java/io/micronaut/servlet/engine/initializer/MicronautServletInitializer.java
+++ b/servlet-engine/src/main/java/io/micronaut/servlet/engine/initializer/MicronautServletInitializer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2023 original authors
+ * Copyright 2017-2026 original authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -26,8 +26,11 @@ import io.micronaut.core.util.StringUtils;
 import io.micronaut.inject.BeanDefinition;
 import io.micronaut.inject.BeanIdentifier;
 import io.micronaut.inject.qualifiers.Qualifiers;
+import io.micronaut.runtime.server.event.ServerShutdownEvent;
+import io.micronaut.runtime.server.event.ServerStartupEvent;
 import io.micronaut.servlet.engine.DefaultMicronautServlet;
 import io.micronaut.servlet.engine.MicronautServletConfiguration;
+import io.micronaut.servlet.engine.server.ServletContextEmbeddedServer;
 import jakarta.inject.Inject;
 import jakarta.servlet.DispatcherType;
 import jakarta.servlet.Filter;
@@ -36,6 +39,8 @@ import jakarta.servlet.MultipartConfigElement;
 import jakarta.servlet.Servlet;
 import jakarta.servlet.ServletContainerInitializer;
 import jakarta.servlet.ServletContext;
+import jakarta.servlet.ServletContextEvent;
+import jakarta.servlet.ServletContextListener;
 import jakarta.servlet.ServletRegistration;
 import jakarta.servlet.ServletSecurityElement;
 import jakarta.servlet.annotation.MultipartConfig;
@@ -90,7 +95,9 @@ public class MicronautServletInitializer implements ServletContainerInitializer 
         final ApplicationContext applicationContext = this.applicationContext != null ? this.applicationContext : buildApplicationContext(ctx)
                 .build()
                 .start();
+        ctx.setAttribute(DefaultMicronautServlet.CONTEXT_ATTRIBUTE, applicationContext);
         final MicronautServletConfiguration configuration = applicationContext.getBean(MicronautServletConfiguration.class);
+        final ServletContextEmbeddedServer servletContextEmbeddedServer = applicationContext.findBean(ServletContextEmbeddedServer.class).orElse(null);
         Collection<BeanRegistration<Servlet>> servlets = applicationContext.getBeanRegistrations(Servlet.class);
         Collection<BeanRegistration<Filter>> filters = applicationContext.getBeanRegistrations(Filter.class);
         Collection<EventListener> servletListeners = applicationContext.getBeansOfType(EventListener.class, Qualifiers.byStereotype(WebListener.class));
@@ -115,7 +122,21 @@ public class MicronautServletInitializer implements ServletContainerInitializer 
         for (EventListener servletListener : servletListeners) {
             ctx.addListener(servletListener);
         }
-
+        if (servletContextEmbeddedServer != null) {
+            servletContextEmbeddedServer.start();
+            applicationContext.publishEvent(new ServerStartupEvent(servletContextEmbeddedServer));
+            ctx.addListener(new ServletContextListener() {
+                @Override
+                public void contextDestroyed(ServletContextEvent sce) {
+                    if (!applicationContext.isRunning()) {
+                        return;
+                    }
+                    applicationContext.publishEvent(new ServerShutdownEvent(servletContextEmbeddedServer));
+                    servletContextEmbeddedServer.stop();
+                    applicationContext.stop();
+                }
+            });
+        }
     }
 
     private static void handleFilterRegistration(ServletContext ctx, BeanRegistration<Filter> beanRegistration) {

--- a/servlet-engine/src/main/java/io/micronaut/servlet/engine/server/ServletContextEmbeddedServer.java
+++ b/servlet-engine/src/main/java/io/micronaut/servlet/engine/server/ServletContextEmbeddedServer.java
@@ -1,0 +1,121 @@
+/*
+ * Copyright 2017-2026 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.servlet.engine.server;
+
+import io.micronaut.context.ApplicationContext;
+import io.micronaut.context.annotation.Requires;
+import io.micronaut.core.annotation.Internal;
+import io.micronaut.runtime.ApplicationConfiguration;
+import io.micronaut.runtime.server.EmbeddedServer;
+import jakarta.inject.Singleton;
+import jakarta.servlet.ServletContext;
+
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.net.URL;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+/**
+ * {@link EmbeddedServer} bridge for servlet-container deployments.
+ */
+@Internal
+@Singleton
+@Requires(beans = ServletContext.class)
+@Requires(missingBeans = EmbeddedServer.class)
+public final class ServletContextEmbeddedServer implements EmbeddedServer {
+    private final ApplicationContext applicationContext;
+    private final ApplicationConfiguration applicationConfiguration;
+    private final ServletContext servletContext;
+    private final AtomicBoolean running = new AtomicBoolean(true);
+
+    public ServletContextEmbeddedServer(ApplicationContext applicationContext,
+                                        ApplicationConfiguration applicationConfiguration,
+                                        ServletContext servletContext) {
+        this.applicationContext = applicationContext;
+        this.applicationConfiguration = applicationConfiguration;
+        this.servletContext = servletContext;
+    }
+
+    @Override
+    public ApplicationContext getApplicationContext() {
+        return applicationContext;
+    }
+
+    @Override
+    public ApplicationConfiguration getApplicationConfiguration() {
+        return applicationConfiguration;
+    }
+
+    @Override
+    public EmbeddedServer start() {
+        running.set(true);
+        return this;
+    }
+
+    @Override
+    public EmbeddedServer stop() {
+        running.set(false);
+        return this;
+    }
+
+    @Override
+    public int getPort() {
+        return applicationContext.getEnvironment()
+            .getProperty("micronaut.server.port", Integer.class)
+            .orElse(-1);
+    }
+
+    @Override
+    public String getHost() {
+        return applicationContext.getEnvironment()
+            .getProperty("micronaut.server.host", String.class)
+            .orElse("localhost");
+    }
+
+    @Override
+    public String getScheme() {
+        boolean sslEnabled = applicationContext.getEnvironment()
+            .getProperty("micronaut.ssl.enabled", Boolean.class)
+            .orElse(false);
+        return sslEnabled ? "https" : "http";
+    }
+
+    @Override
+    public URL getURL() {
+        try {
+            return getURI().toURL();
+        } catch (Exception e) {
+            throw new IllegalStateException("Invalid servlet container URL", e);
+        }
+    }
+
+    @Override
+    public URI getURI() {
+        String contextPath = servletContext.getContextPath();
+        String path = contextPath == null || contextPath.isEmpty() ? null : contextPath;
+        int port = getPort();
+        try {
+            return new URI(getScheme(), null, getHost(), port > 0 ? port : -1, path, null, null);
+        } catch (URISyntaxException e) {
+            throw new IllegalStateException("Invalid servlet container URI", e);
+        }
+    }
+
+    @Override
+    public boolean isRunning() {
+        return running.get() && applicationContext.isRunning();
+    }
+}

--- a/servlet-engine/src/test/java/io/micronaut/servlet/engine/initializer/MicronautServletInitializerTest.java
+++ b/servlet-engine/src/test/java/io/micronaut/servlet/engine/initializer/MicronautServletInitializerTest.java
@@ -30,10 +30,12 @@ import jakarta.servlet.ServletContextListener;
 import jakarta.servlet.ServletRegistration;
 import org.junit.jupiter.api.Test;
 
+import java.lang.reflect.Field;
 import java.lang.reflect.Proxy;
 import java.util.Collections;
 import java.util.Map;
 import java.util.Set;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
@@ -60,11 +62,13 @@ class MicronautServletInitializerTest {
             .build()
             .start()) {
             ServerEventRecorder recorder = applicationContext.getBean(ServerEventRecorder.class);
+            ServletContextEmbeddedServer embeddedServer = applicationContext.getBean(ServletContextEmbeddedServer.class);
 
             new MicronautServletInitializer(applicationContext).onStartup(Set.of(), servletContext);
 
             assertEquals(1, recorder.startupCount.get());
             assertSame(applicationContext, servletContext.getAttribute(CONTEXT_ATTRIBUTE));
+            assertTrue(runningFlag(embeddedServer));
 
             ServletContextListener listener = shutdownListener.get();
             assertNotNull(listener);
@@ -72,6 +76,7 @@ class MicronautServletInitializerTest {
             listener.contextDestroyed(new ServletContextEvent(servletContext));
 
             assertEquals(1, recorder.shutdownCount.get());
+            assertFalse(runningFlag(embeddedServer));
             assertFalse(applicationContext.isRunning());
         }
     }
@@ -203,6 +208,16 @@ class MicronautServletInitializerTest {
             return Collections.emptySet();
         }
         return null;
+    }
+
+    private static boolean runningFlag(ServletContextEmbeddedServer embeddedServer) {
+        try {
+            Field field = ServletContextEmbeddedServer.class.getDeclaredField("running");
+            field.setAccessible(true);
+            return ((AtomicBoolean) field.get(embeddedServer)).get();
+        } catch (ReflectiveOperationException e) {
+            throw new AssertionError(e);
+        }
     }
 
     @Singleton

--- a/servlet-engine/src/test/java/io/micronaut/servlet/engine/initializer/MicronautServletInitializerTest.java
+++ b/servlet-engine/src/test/java/io/micronaut/servlet/engine/initializer/MicronautServletInitializerTest.java
@@ -1,0 +1,142 @@
+/*
+ * Copyright 2017-2026 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.servlet.engine.initializer;
+
+import io.micronaut.context.ApplicationContext;
+import io.micronaut.context.annotation.Requires;
+import io.micronaut.runtime.event.annotation.EventListener;
+import io.micronaut.runtime.server.event.ServerShutdownEvent;
+import io.micronaut.runtime.server.event.ServerStartupEvent;
+import jakarta.inject.Singleton;
+import jakarta.servlet.FilterRegistration;
+import jakarta.servlet.Servlet;
+import jakarta.servlet.ServletContext;
+import jakarta.servlet.ServletContextEvent;
+import jakarta.servlet.ServletContextListener;
+import jakarta.servlet.ServletRegistration;
+import org.junit.jupiter.api.Test;
+
+import java.lang.reflect.Proxy;
+import java.util.Collections;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
+
+import static io.micronaut.servlet.engine.DefaultMicronautServlet.CONTEXT_ATTRIBUTE;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+
+class MicronautServletInitializerTest {
+
+    @Test
+    void publishesServerLifecycleEventsForExternalServletContexts() {
+        AtomicReference<ServletContextListener> shutdownListener = new AtomicReference<>();
+        ServletContext servletContext = servletContext(shutdownListener);
+
+        try (ApplicationContext applicationContext = ApplicationContext.builder()
+            .properties(Map.of("spec.name", "MicronautServletInitializerTest"))
+            .singletons(servletContext)
+            .build()
+            .start()) {
+            ServerEventRecorder recorder = applicationContext.getBean(ServerEventRecorder.class);
+
+            new MicronautServletInitializer(applicationContext).onStartup(Set.of(), servletContext);
+
+            assertEquals(1, recorder.startupCount.get());
+            assertSame(applicationContext, servletContext.getAttribute(CONTEXT_ATTRIBUTE));
+
+            ServletContextListener listener = shutdownListener.get();
+            assertNotNull(listener);
+
+            listener.contextDestroyed(new ServletContextEvent(servletContext));
+
+            assertEquals(1, recorder.shutdownCount.get());
+            assertFalse(applicationContext.isRunning());
+        }
+    }
+
+    private static ServletContext servletContext(AtomicReference<ServletContextListener> shutdownListener) {
+        Map<String, Object> attributes = new ConcurrentHashMap<>();
+        return (ServletContext) Proxy.newProxyInstance(
+            MicronautServletInitializerTest.class.getClassLoader(),
+            new Class<?>[]{ServletContext.class},
+            (proxy, method, args) -> switch (method.getName()) {
+                case "addFilter" -> registration(FilterRegistration.Dynamic.class);
+                case "addListener" -> {
+                    if (args[0] instanceof ServletContextListener listener) {
+                        shutdownListener.set(listener);
+                    }
+                    yield null;
+                }
+                case "addServlet" -> registration(ServletRegistration.Dynamic.class);
+                case "getAttribute" -> attributes.get(args[0]);
+                case "getAttributeNames" -> Collections.enumeration(attributes.keySet());
+                case "getClassLoader" -> MicronautServletInitializerTest.class.getClassLoader();
+                case "getContextPath" -> "";
+                case "setAttribute" -> {
+                    attributes.put((String) args[0], args[1]);
+                    yield null;
+                }
+                default -> defaultValue(method.getReturnType());
+            }
+        );
+    }
+
+    private static <T> T registration(Class<T> type) {
+        return type.cast(Proxy.newProxyInstance(
+            MicronautServletInitializerTest.class.getClassLoader(),
+            new Class<?>[]{type},
+            (proxy, method, args) -> defaultValue(method.getReturnType())
+        ));
+    }
+
+    private static Object defaultValue(Class<?> returnType) {
+        if (returnType == Void.TYPE) {
+            return null;
+        }
+        if (returnType == Boolean.TYPE) {
+            return false;
+        }
+        if (returnType == Integer.TYPE) {
+            return 0;
+        }
+        if (Set.class.isAssignableFrom(returnType)) {
+            return Collections.emptySet();
+        }
+        return null;
+    }
+
+    @Singleton
+    @Requires(property = "spec.name", value = "MicronautServletInitializerTest")
+    static final class ServerEventRecorder {
+        private final AtomicInteger startupCount = new AtomicInteger();
+        private final AtomicInteger shutdownCount = new AtomicInteger();
+
+        @EventListener
+        void onStartup(ServerStartupEvent event) {
+            startupCount.incrementAndGet();
+        }
+
+        @EventListener
+        void onShutdown(ServerShutdownEvent event) {
+            shutdownCount.incrementAndGet();
+        }
+    }
+}

--- a/servlet-engine/src/test/java/io/micronaut/servlet/engine/initializer/MicronautServletInitializerTest.java
+++ b/servlet-engine/src/test/java/io/micronaut/servlet/engine/initializer/MicronautServletInitializerTest.java
@@ -16,13 +16,14 @@
 package io.micronaut.servlet.engine.initializer;
 
 import io.micronaut.context.ApplicationContext;
+import io.micronaut.context.ApplicationContextBuilder;
 import io.micronaut.context.annotation.Requires;
 import io.micronaut.runtime.event.annotation.EventListener;
 import io.micronaut.runtime.server.event.ServerShutdownEvent;
 import io.micronaut.runtime.server.event.ServerStartupEvent;
+import io.micronaut.servlet.engine.server.ServletContextEmbeddedServer;
 import jakarta.inject.Singleton;
 import jakarta.servlet.FilterRegistration;
-import jakarta.servlet.Servlet;
 import jakarta.servlet.ServletContext;
 import jakarta.servlet.ServletContextEvent;
 import jakarta.servlet.ServletContextListener;
@@ -41,9 +42,12 @@ import static io.micronaut.servlet.engine.DefaultMicronautServlet.CONTEXT_ATTRIB
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 class MicronautServletInitializerTest {
+    private static final String SPEC_NAME = "MicronautServletInitializerTest";
 
     @Test
     void publishesServerLifecycleEventsForExternalServletContexts() {
@@ -51,7 +55,7 @@ class MicronautServletInitializerTest {
         ServletContext servletContext = servletContext(shutdownListener);
 
         try (ApplicationContext applicationContext = ApplicationContext.builder()
-            .properties(Map.of("spec.name", "MicronautServletInitializerTest"))
+            .properties(Map.of("spec.name", SPEC_NAME))
             .singletons(servletContext)
             .build()
             .start()) {
@@ -72,7 +76,85 @@ class MicronautServletInitializerTest {
         }
     }
 
+    @Test
+    void ignoresContainerShutdownWhenApplicationContextIsAlreadyStopped() {
+        AtomicReference<ServletContextListener> shutdownListener = new AtomicReference<>();
+        ServletContext servletContext = servletContext(shutdownListener);
+
+        try (ApplicationContext applicationContext = ApplicationContext.builder()
+            .properties(Map.of("spec.name", SPEC_NAME))
+            .singletons(servletContext)
+            .build()
+            .start()) {
+            ServerEventRecorder recorder = applicationContext.getBean(ServerEventRecorder.class);
+
+            new MicronautServletInitializer(applicationContext).onStartup(Set.of(), servletContext);
+
+            ServletContextListener listener = shutdownListener.get();
+            assertNotNull(listener);
+            applicationContext.stop();
+
+            listener.contextDestroyed(new ServletContextEvent(servletContext));
+
+            assertEquals(1, recorder.startupCount.get());
+            assertEquals(0, recorder.shutdownCount.get());
+        }
+    }
+
+    @Test
+    void buildsApplicationContextFromServletContextWhenNotInjected() {
+        AtomicReference<ServletContextListener> shutdownListener = new AtomicReference<>();
+        ServletContext servletContext = servletContext("/demo", shutdownListener);
+
+        new MicronautServletInitializer() {
+            @Override
+            protected ApplicationContextBuilder buildApplicationContext(ServletContext ctx) {
+                return super.buildApplicationContext(ctx).properties(Map.of("spec.name", SPEC_NAME));
+            }
+        }.onStartup(Set.of(), servletContext);
+
+        ApplicationContext applicationContext = (ApplicationContext) servletContext.getAttribute(CONTEXT_ATTRIBUTE);
+        assertNotNull(applicationContext);
+        assertEquals("/demo", applicationContext.getEnvironment().getProperty("micronaut.server.context-path", String.class).orElseThrow());
+
+        ServerEventRecorder recorder = applicationContext.getBean(ServerEventRecorder.class);
+        ServletContextEmbeddedServer embeddedServer = applicationContext.getBean(ServletContextEmbeddedServer.class);
+        assertEquals(1, recorder.startupCount.get());
+        assertTrue(embeddedServer.isRunning());
+
+        ServletContextListener listener = shutdownListener.get();
+        assertNotNull(listener);
+        listener.contextDestroyed(new ServletContextEvent(servletContext));
+
+        assertEquals(1, recorder.shutdownCount.get());
+        assertFalse(applicationContext.isRunning());
+    }
+
+    @Test
+    void skipsLifecycleEventsWhenEmbeddedServerBeanIsMissing() {
+        AtomicReference<ServletContextListener> shutdownListener = new AtomicReference<>();
+        ServletContext servletContext = servletContext(shutdownListener);
+
+        try (ApplicationContext applicationContext = ApplicationContext.builder()
+            .properties(Map.of("spec.name", SPEC_NAME))
+            .build()
+            .start()) {
+            ServerEventRecorder recorder = applicationContext.getBean(ServerEventRecorder.class);
+
+            new MicronautServletInitializer(applicationContext).onStartup(Set.of(), servletContext);
+
+            assertSame(applicationContext, servletContext.getAttribute(CONTEXT_ATTRIBUTE));
+            assertNull(shutdownListener.get());
+            assertEquals(0, recorder.startupCount.get());
+            assertEquals(0, recorder.shutdownCount.get());
+        }
+    }
+
     private static ServletContext servletContext(AtomicReference<ServletContextListener> shutdownListener) {
+        return servletContext("", shutdownListener);
+    }
+
+    private static ServletContext servletContext(String contextPath, AtomicReference<ServletContextListener> shutdownListener) {
         Map<String, Object> attributes = new ConcurrentHashMap<>();
         return (ServletContext) Proxy.newProxyInstance(
             MicronautServletInitializerTest.class.getClassLoader(),
@@ -89,7 +171,7 @@ class MicronautServletInitializerTest {
                 case "getAttribute" -> attributes.get(args[0]);
                 case "getAttributeNames" -> Collections.enumeration(attributes.keySet());
                 case "getClassLoader" -> MicronautServletInitializerTest.class.getClassLoader();
-                case "getContextPath" -> "";
+                case "getContextPath" -> contextPath;
                 case "setAttribute" -> {
                     attributes.put((String) args[0], args[1]);
                     yield null;
@@ -124,7 +206,7 @@ class MicronautServletInitializerTest {
     }
 
     @Singleton
-    @Requires(property = "spec.name", value = "MicronautServletInitializerTest")
+    @Requires(property = "spec.name", value = SPEC_NAME)
     static final class ServerEventRecorder {
         private final AtomicInteger startupCount = new AtomicInteger();
         private final AtomicInteger shutdownCount = new AtomicInteger();

--- a/servlet-engine/src/test/java/io/micronaut/servlet/engine/server/ServletContextEmbeddedServerTest.java
+++ b/servlet-engine/src/test/java/io/micronaut/servlet/engine/server/ServletContextEmbeddedServerTest.java
@@ -84,6 +84,19 @@ class ServletContextEmbeddedServerTest {
         }
     }
 
+    @Test
+    void usesRootUriWhenContextPathIsNull() {
+        try (ApplicationContext applicationContext = ApplicationContext.builder()
+            .singletons(servletContext(null))
+            .build()
+            .start()) {
+            ServletContextEmbeddedServer embeddedServer = applicationContext.getBean(ServletContextEmbeddedServer.class);
+
+            assertEquals(URI.create("http://localhost"), embeddedServer.getURI());
+            assertNotNull(embeddedServer.getURL());
+        }
+    }
+
     private static ServletContext servletContext(String contextPath) {
         return (ServletContext) Proxy.newProxyInstance(
             ServletContextEmbeddedServerTest.class.getClassLoader(),

--- a/servlet-engine/src/test/java/io/micronaut/servlet/engine/server/ServletContextEmbeddedServerTest.java
+++ b/servlet-engine/src/test/java/io/micronaut/servlet/engine/server/ServletContextEmbeddedServerTest.java
@@ -1,0 +1,111 @@
+/*
+ * Copyright 2017-2026 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.servlet.engine.server;
+
+import io.micronaut.context.ApplicationContext;
+import io.micronaut.runtime.ApplicationConfiguration;
+import jakarta.servlet.ServletContext;
+import org.junit.jupiter.api.Test;
+
+import java.lang.reflect.Proxy;
+import java.net.URI;
+import java.net.URL;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class ServletContextEmbeddedServerTest {
+
+    @Test
+    void resolvesConfiguredServerMetadataAndLifecycleState() throws Exception {
+        ServletContext servletContext = servletContext("/demo");
+
+        try (ApplicationContext applicationContext = ApplicationContext.builder()
+            .singletons(servletContext)
+            .properties(Map.of(
+                "micronaut.server.host", "example.com",
+                "micronaut.server.port", 8443,
+                "micronaut.ssl.enabled", true
+            ))
+            .build()
+            .start()) {
+            ServletContextEmbeddedServer embeddedServer = applicationContext.getBean(ServletContextEmbeddedServer.class);
+
+            assertSame(applicationContext, embeddedServer.getApplicationContext());
+            assertSame(applicationContext.getBean(ApplicationConfiguration.class), embeddedServer.getApplicationConfiguration());
+            assertEquals("example.com", embeddedServer.getHost());
+            assertEquals(8443, embeddedServer.getPort());
+            assertEquals("https", embeddedServer.getScheme());
+            assertEquals(new URI("https://example.com:8443/demo"), embeddedServer.getURI());
+            assertEquals(new URL("https://example.com:8443/demo"), embeddedServer.getURL());
+            assertTrue(embeddedServer.isRunning());
+
+            embeddedServer.stop();
+            assertFalse(embeddedServer.isRunning());
+
+            embeddedServer.start();
+            assertTrue(embeddedServer.isRunning());
+
+            applicationContext.stop();
+            assertFalse(embeddedServer.isRunning());
+        }
+    }
+
+    @Test
+    void usesDefaultHostSchemeAndPortWhenNotConfigured() {
+        try (ApplicationContext applicationContext = ApplicationContext.builder()
+            .singletons(servletContext(""))
+            .build()
+            .start()) {
+            ServletContextEmbeddedServer embeddedServer = applicationContext.getBean(ServletContextEmbeddedServer.class);
+
+            assertEquals("localhost", embeddedServer.getHost());
+            assertEquals(-1, embeddedServer.getPort());
+            assertEquals("http", embeddedServer.getScheme());
+            assertEquals(URI.create("http://localhost"), embeddedServer.getURI());
+            assertNotNull(embeddedServer.getURL());
+        }
+    }
+
+    private static ServletContext servletContext(String contextPath) {
+        return (ServletContext) Proxy.newProxyInstance(
+            ServletContextEmbeddedServerTest.class.getClassLoader(),
+            new Class<?>[]{ServletContext.class},
+            (proxy, method, args) -> switch (method.getName()) {
+                case "getClassLoader" -> ServletContextEmbeddedServerTest.class.getClassLoader();
+                case "getContextPath" -> contextPath;
+                default -> defaultValue(method.getReturnType());
+            }
+        );
+    }
+
+    private static Object defaultValue(Class<?> returnType) {
+        if (returnType == Void.TYPE) {
+            return null;
+        }
+        if (returnType == Boolean.TYPE) {
+            return false;
+        }
+        if (returnType == Integer.TYPE) {
+            return 0;
+        }
+        return null;
+    }
+}


### PR DESCRIPTION
## Summary
- publish `ServerStartupEvent` and `ServerShutdownEvent` for servlet-container WAR deployments
- bridge external servlet deployments to an `EmbeddedServer` so server lifecycle listeners behave like the embedded servlet servers
- add a focused servlet-engine regression test for WAR startup and shutdown event publication

## Verification
- `./gradlew :micronaut-servlet-engine:test --tests io.micronaut.servlet.engine.initializer.MicronautServletInitializerTest`
- `./gradlew :micronaut-http-server-jetty:test --tests io.micronaut.servlet.jetty.JettyServletAnnotationSpec`

Resolves #976
