### PR TITLE
Fix Jetty CORS simple request TCK handling

### DIFF
--- a/buildSrc/src/main/groovy/io.micronaut.build.internal.servlet.http-server-tck-module.gradle
+++ b/buildSrc/src/main/groovy/io.micronaut.build.internal.servlet.http-server-tck-module.gradle
@@ -33,7 +33,9 @@ graalvmNative {
     binaries {
         all {
             resources.autodetect()
-            buildArgs.add("-H:+SharedArenaSupport")
+            if (JavaVersion.current().majorVersion.toInteger() >= 25) {
+                buildArgs.add("-H:+SharedArenaSupport")
+            }
         }
     }
 }

--- a/http-server-jetty/src/main/java/io/micronaut/servlet/jetty/JettyServletHttpHandler.java
+++ b/http-server-jetty/src/main/java/io/micronaut/servlet/jetty/JettyServletHttpHandler.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright 2017-2026 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.servlet.jetty;
+
+import io.micronaut.context.ApplicationContext;
+import io.micronaut.context.annotation.Replaces;
+import io.micronaut.core.convert.ConversionService;
+import io.micronaut.scheduling.TaskExecutors;
+import io.micronaut.servlet.engine.DefaultServletHttpHandler;
+import io.micronaut.servlet.http.BodyBuilder;
+import io.micronaut.servlet.http.SSLSessionProvider;
+import io.micronaut.servlet.http.ServletExchange;
+import jakarta.inject.Inject;
+import jakarta.inject.Named;
+import jakarta.inject.Singleton;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.jspecify.annotations.Nullable;
+
+import java.util.concurrent.Executor;
+
+@Singleton
+@Replaces(DefaultServletHttpHandler.class)
+final class JettyServletHttpHandler extends DefaultServletHttpHandler {
+    @Inject
+    JettyServletHttpHandler(ApplicationContext applicationContext,
+                            ConversionService conversionService,
+                            @Named(TaskExecutors.BLOCKING) Executor ioExecutor,
+                            @Nullable SSLSessionProvider sslSessionProvider) {
+        super(applicationContext, conversionService, ioExecutor, sslSessionProvider);
+    }
+
+    @Override
+    protected ServletExchange<HttpServletRequest, HttpServletResponse> createExchange(HttpServletRequest request,
+                                                                                      HttpServletResponse response) {
+        return new JettyServletHttpRequest<>(
+            getApplicationContext().getConversionService(),
+            request,
+            response,
+            getMessageBodyHandlerRegistry(),
+            getApplicationContext().getBean(BodyBuilder.class),
+            getIoExecutor(),
+            getSslSessionProvider()
+        );
+    }
+}

--- a/http-server-jetty/src/main/java/io/micronaut/servlet/jetty/JettyServletHttpRequest.java
+++ b/http-server-jetty/src/main/java/io/micronaut/servlet/jetty/JettyServletHttpRequest.java
@@ -22,11 +22,13 @@ import io.micronaut.servlet.engine.DefaultServletHttpRequest;
 import io.micronaut.servlet.http.BodyBuilder;
 import io.micronaut.servlet.http.SSLSessionProvider;
 import jakarta.servlet.ServletRequest;
-import jakarta.servlet.ServletRequestWrapper;
+import jakarta.servlet.ServletInputStream;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import org.eclipse.jetty.ee10.servlet.ServletApiRequest;
+import org.eclipse.jetty.ee10.servlet.ServletCoreRequest;
 
+import java.io.IOException;
 import java.util.concurrent.Executor;
 
 @Internal
@@ -44,8 +46,17 @@ final class JettyServletHttpRequest<B> extends DefaultServletHttpRequest<B> {
     @Override
     protected boolean prepareUnusedFormBodyForResponse() {
         ServletRequest request = delegate();
-        while (request instanceof ServletRequestWrapper wrapper) {
-            request = wrapper.getRequest();
+        if (request instanceof HttpServletRequest httpServletRequest) {
+            try {
+                ServletInputStream inputStream = httpServletRequest.getInputStream();
+                byte[] buffer = new byte[8192];
+                while (inputStream.read(buffer) != -1) {
+                    // Fully drain the request before handing control back to Jetty.
+                }
+            } catch (IOException ignored) {
+                // Fall through to Jetty's best-effort request consumption below.
+            }
+            return ServletCoreRequest.wrap(httpServletRequest).consumeAvailable();
         }
         if (request instanceof ServletApiRequest servletApiRequest) {
             return servletApiRequest.getRequest().consumeAvailable();

--- a/http-server-jetty/src/main/java/io/micronaut/servlet/jetty/JettyServletHttpRequest.java
+++ b/http-server-jetty/src/main/java/io/micronaut/servlet/jetty/JettyServletHttpRequest.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2017-2026 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.servlet.jetty;
+
+import io.micronaut.core.annotation.Internal;
+import io.micronaut.core.convert.ConversionService;
+import io.micronaut.http.body.MessageBodyHandlerRegistry;
+import io.micronaut.servlet.engine.DefaultServletHttpRequest;
+import io.micronaut.servlet.http.BodyBuilder;
+import io.micronaut.servlet.http.SSLSessionProvider;
+import jakarta.servlet.ServletRequest;
+import jakarta.servlet.ServletRequestWrapper;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.eclipse.jetty.ee10.servlet.ServletApiRequest;
+
+import java.util.concurrent.Executor;
+
+@Internal
+final class JettyServletHttpRequest<B> extends DefaultServletHttpRequest<B> {
+    JettyServletHttpRequest(ConversionService conversionService,
+                            HttpServletRequest delegate,
+                            HttpServletResponse response,
+                            MessageBodyHandlerRegistry messageBodyHandlerRegistry,
+                            BodyBuilder bodyBuilder,
+                            Executor ioExecutor,
+                            SSLSessionProvider sslSessionProvider) {
+        super(conversionService, delegate, response, messageBodyHandlerRegistry, bodyBuilder, ioExecutor, sslSessionProvider);
+    }
+
+    @Override
+    protected boolean prepareUnusedFormBodyForResponse() {
+        ServletRequest request = delegate();
+        while (request instanceof ServletRequestWrapper wrapper) {
+            request = wrapper.getRequest();
+        }
+        if (request instanceof ServletApiRequest servletApiRequest) {
+            return servletApiRequest.getRequest().consumeAvailable();
+        }
+        return false;
+    }
+}

--- a/http-server-jetty/src/main/java/io/micronaut/servlet/jetty/JettyServletHttpRequest.java
+++ b/http-server-jetty/src/main/java/io/micronaut/servlet/jetty/JettyServletHttpRequest.java
@@ -50,8 +50,11 @@ final class JettyServletHttpRequest<B> extends DefaultServletHttpRequest<B> {
             try {
                 ServletInputStream inputStream = httpServletRequest.getInputStream();
                 byte[] buffer = new byte[8192];
-                while (inputStream.read(buffer) != -1) {
-                    // Fully drain the request before handing control back to Jetty.
+                while (true) {
+                    int read = inputStream.read(buffer);
+                    if (read == -1) {
+                        break;
+                    }
                 }
             } catch (IOException ignored) {
                 // Fall through to Jetty's best-effort request consumption below.

--- a/servlet-core/src/main/java/io/micronaut/servlet/http/ServletHttpHandler.java
+++ b/servlet-core/src/main/java/io/micronaut/servlet/http/ServletHttpHandler.java
@@ -169,6 +169,8 @@ public abstract class ServletHttpHandler<REQ, RES> implements AutoCloseable, Lif
             return;
         }
 
+        exchange.getRequest().prepareForResponse();
+
         traceHeaders(byteBodyResponse.getHeaders());
 
         ServletHttpResponse<?, ?> servletResponse = exchange.getResponse();

--- a/servlet-core/src/main/java/io/micronaut/servlet/http/ServletHttpRequest.java
+++ b/servlet-core/src/main/java/io/micronaut/servlet/http/ServletHttpRequest.java
@@ -92,6 +92,17 @@ public interface ServletHttpRequest<N, B> extends HttpRequest<B> {
     }
 
     /**
+     * Prepare the request for writing a response.
+     *
+     * <p>Servlet containers may require unread request bodies such as form or multipart content
+     * to be consumed before the response is committed. Implementations may use this hook to let
+     * the native container perform that consumption when no application code has already claimed
+     * the request body.
+     */
+    default void prepareForResponse() {
+    }
+
+    /**
      * Async execution callback.
      *
      * @author Denis Stepanov

--- a/servlet-engine/src/main/java/io/micronaut/servlet/engine/DefaultServletHttpHandler.java
+++ b/servlet-engine/src/main/java/io/micronaut/servlet/engine/DefaultServletHttpHandler.java
@@ -112,4 +112,12 @@ public class DefaultServletHttpHandler extends ServletHttpHandler<HttpServletReq
     public boolean isRunning() {
         return getApplicationContext().isRunning();
     }
+
+    protected final Executor getIoExecutor() {
+        return ioExecutor;
+    }
+
+    protected final @Nullable SSLSessionProvider getSslSessionProvider() {
+        return sslSessionProvider;
+    }
 }

--- a/servlet-engine/src/main/java/io/micronaut/servlet/engine/DefaultServletHttpRequest.java
+++ b/servlet-engine/src/main/java/io/micronaut/servlet/engine/DefaultServletHttpRequest.java
@@ -99,7 +99,7 @@ import java.util.function.Supplier;
  * @since 1.0.0
  */
 @Internal
-public final class DefaultServletHttpRequest<B> implements
+public class DefaultServletHttpRequest<B> implements
     ServletHttpRequest<HttpServletRequest, B>,
     ServletExchange<HttpServletRequest, HttpServletResponse>,
     StreamedServletMessage<B, byte[]>,
@@ -119,7 +119,7 @@ public final class DefaultServletHttpRequest<B> implements
     private DefaultServletHttpResponse<B> primaryResponse;
     private final MessageBodyHandlerRegistry messageBodyHandlerRegistry;
     private final MutableConvertibleValues<Object> attributes;
-    private final CloseableByteBody byteBody;
+    private volatile CloseableByteBody byteBody;
     private final ByteBodyFactory byteBodyFactory;
     private final Executor ioExecutor;
     private final SSLSessionProvider sslSessionProvider;
@@ -128,6 +128,7 @@ public final class DefaultServletHttpRequest<B> implements
     private List<Runnable> disposalResources;
 
     private boolean bodyIsReadAsync;
+    private boolean bodyAccessed;
     private B parsedBody;
     private AsyncContext asyncContext;
 
@@ -161,27 +162,20 @@ public final class DefaultServletHttpRequest<B> implements
      * @param ioExecutor         Executor for blocking operations
      * @param sslSessionProvider The {@link SSLSession} provider from attribute
      */
-    DefaultServletHttpRequest(ConversionService conversionService,
-                              HttpServletRequest delegate,
-                              HttpServletResponse response,
-                              MessageBodyHandlerRegistry messageBodyHandlerRegistry,
-                              BodyBuilder bodyBuilder,
-                              Executor ioExecutor,
-                              @Nullable SSLSessionProvider sslSessionProvider) {
+    protected DefaultServletHttpRequest(ConversionService conversionService,
+                                        HttpServletRequest delegate,
+                                        HttpServletResponse response,
+                                        MessageBodyHandlerRegistry messageBodyHandlerRegistry,
+                                        BodyBuilder bodyBuilder,
+                                        Executor ioExecutor,
+                                        @Nullable SSLSessionProvider sslSessionProvider) {
         super();
         this.conversionService = conversionService;
         this.delegate = delegate;
         this.messageBodyHandlerRegistry = messageBodyHandlerRegistry;
         this.ioExecutor = ioExecutor;
         this.sslSessionProvider = sslSessionProvider;
-        long contentLengthLong = delegate.getContentLengthLong();
-        OptionalLong length = contentLengthLong < 0 ? OptionalLong.empty() : OptionalLong.of(contentLengthLong);
         this.byteBodyFactory = ByteBodyFactory.createDefault(ByteArrayBufferFactory.INSTANCE);
-        if (delegate.isAsyncSupported()) {
-            this.byteBody = ByteBufferBodyAdapter.adapt(new ServletStreamPublisher(delegate::getInputStream), length);
-        } else {
-            this.byteBody = InputStreamByteBody.create(new LazyDelegateInputStream(delegate), length, ioExecutor, byteBodyFactory);
-        }
 
         String requestURI = resolveRequestUri(delegate);
 
@@ -380,7 +374,7 @@ public final class DefaultServletHttpRequest<B> implements
         );
     }
 
-    private ServletRequest delegate() {
+    protected final ServletRequest delegate() {
         return asyncContext != null ? asyncContext.getRequest() : delegate;
     }
 
@@ -536,7 +530,18 @@ public final class DefaultServletHttpRequest<B> implements
 
     @Override
     public @NonNull ByteBody byteBody() {
-        return byteBody;
+        bodyAccessed = true;
+        CloseableByteBody body = byteBody;
+        if (body == null) {
+            synchronized (this) {
+                body = byteBody;
+                if (body == null) {
+                    body = createByteBody();
+                    byteBody = body;
+                }
+            }
+        }
+        return body;
     }
 
     @Override
@@ -546,8 +551,15 @@ public final class DefaultServletHttpRequest<B> implements
 
     @Override
     public void close() {
-        byteBody.close();
         runDisposalResources();
+    }
+
+    @Override
+    public void prepareForResponse() {
+        if (bodyAccessed || !hasFormBody()) {
+            return;
+        }
+        bodyAccessed = prepareUnusedFormBodyForResponse();
     }
 
     @Override
@@ -571,10 +583,12 @@ public final class DefaultServletHttpRequest<B> implements
         if (mediaType == null || !isFormContentType(mediaType)) {
             throw new IllegalStateException("Not a form Content-Type. Please check hasFormBody() before calling this method.");
         }
+        bodyAccessed = true;
         if (mediaType.matches(MediaType.MULTIPART_FORM_DATA_TYPE)) {
             return Flux.defer(() -> {
                 try {
                     Collection<Part> parts = ((HttpServletRequest) delegate()).getParts();
+                    discardByteBodyIfInitialized();
                     return Flux.fromIterable(parts)
                         .map(this::toRawFormFieldFromPart);
                 } catch (IOException | ServletException e) {
@@ -582,11 +596,32 @@ public final class DefaultServletHttpRequest<B> implements
                 }
             });
         } else {
-            return Flux.fromIterable(delegate().getParameterMap().entrySet().stream()
+            return Flux.defer(() -> {
+                var parameterMap = delegate().getParameterMap();
+                discardByteBodyIfInitialized();
+                return Flux.fromIterable(parameterMap.entrySet().stream()
                 .flatMap(entry -> Arrays.stream(entry.getValue())
                     .map(value -> new RawFormField(new FormFieldMetadata(entry.getKey(), null, null), byteBodyFactory().adapt(value.getBytes(StandardCharsets.UTF_8)))))
-                .toList());
+                    .toList());
+            });
         }
+    }
+
+    private void discardByteBodyIfInitialized() {
+        CloseableByteBody body = byteBody;
+        if (body != null) {
+            body.allowDiscard();
+        }
+    }
+
+    protected boolean prepareUnusedFormBodyForResponse() {
+        return false;
+    }
+
+    private CloseableByteBody createByteBody() {
+        long contentLengthLong = delegate.getContentLengthLong();
+        OptionalLong length = contentLengthLong < 0 ? OptionalLong.empty() : OptionalLong.of(contentLengthLong);
+        return InputStreamByteBody.create(new LazyDelegateInputStream(delegate), length, ioExecutor, byteBodyFactory);
     }
 
     @Override

--- a/servlet-engine/src/main/java/io/micronaut/servlet/engine/DefaultServletHttpRequest.java
+++ b/servlet-engine/src/main/java/io/micronaut/servlet/engine/DefaultServletHttpRequest.java
@@ -551,7 +551,14 @@ public class DefaultServletHttpRequest<B> implements
 
     @Override
     public void close() {
-        runDisposalResources();
+        CloseableByteBody body = byteBody;
+        try {
+            if (body != null) {
+                body.close();
+            }
+        } finally {
+            runDisposalResources();
+        }
     }
 
     @Override
@@ -583,9 +590,9 @@ public class DefaultServletHttpRequest<B> implements
         if (mediaType == null || !isFormContentType(mediaType)) {
             throw new IllegalStateException("Not a form Content-Type. Please check hasFormBody() before calling this method.");
         }
-        bodyAccessed = true;
         if (mediaType.matches(MediaType.MULTIPART_FORM_DATA_TYPE)) {
             return Flux.defer(() -> {
+                bodyAccessed = true;
                 try {
                     Collection<Part> parts = ((HttpServletRequest) delegate()).getParts();
                     discardByteBodyIfInitialized();
@@ -597,6 +604,7 @@ public class DefaultServletHttpRequest<B> implements
             });
         } else {
             return Flux.defer(() -> {
+                bodyAccessed = true;
                 var parameterMap = delegate().getParameterMap();
                 discardByteBodyIfInitialized();
                 return Flux.fromIterable(parameterMap.entrySet().stream()
@@ -614,14 +622,25 @@ public class DefaultServletHttpRequest<B> implements
         }
     }
 
+    /**
+     * Called by {@link #prepareForResponse()} when the request has a form body that has not been
+     * accessed. Subclasses can override this to consume or drain the unread form body before the
+     * response is committed.
+     *
+     * @return {@code true} if the body was handled (preventing the default no-op behavior)
+     */
     protected boolean prepareUnusedFormBodyForResponse() {
         return false;
     }
 
     private CloseableByteBody createByteBody() {
-        long contentLengthLong = delegate.getContentLengthLong();
+        HttpServletRequest currentRequest = (HttpServletRequest) delegate();
+        long contentLengthLong = currentRequest.getContentLengthLong();
         OptionalLong length = contentLengthLong < 0 ? OptionalLong.empty() : OptionalLong.of(contentLengthLong);
-        return InputStreamByteBody.create(new LazyDelegateInputStream(delegate), length, ioExecutor, byteBodyFactory);
+        if (isAsyncSupported()) {
+            return ByteBufferBodyAdapter.adapt(new ServletStreamPublisher(currentRequest::getInputStream), length);
+        }
+        return InputStreamByteBody.create(new LazyDelegateInputStream(currentRequest), length, ioExecutor, byteBodyFactory);
     }
 
     @Override

--- a/servlet-engine/src/main/java/io/micronaut/servlet/engine/DefaultServletHttpRequest.java
+++ b/servlet-engine/src/main/java/io/micronaut/servlet/engine/DefaultServletHttpRequest.java
@@ -89,6 +89,7 @@ import java.util.Optional;
 import java.util.OptionalLong;
 import java.util.Set;
 import java.util.concurrent.Executor;
+import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Supplier;
 
 /**
@@ -119,7 +120,7 @@ public class DefaultServletHttpRequest<B> implements
     private DefaultServletHttpResponse<B> primaryResponse;
     private final MessageBodyHandlerRegistry messageBodyHandlerRegistry;
     private final MutableConvertibleValues<Object> attributes;
-    private volatile CloseableByteBody byteBody;
+    private final AtomicReference<CloseableByteBody> byteBody = new AtomicReference<>();
     private final ByteBodyFactory byteBodyFactory;
     private final Executor ioExecutor;
     private final SSLSessionProvider sslSessionProvider;
@@ -531,17 +532,17 @@ public class DefaultServletHttpRequest<B> implements
     @Override
     public @NonNull ByteBody byteBody() {
         bodyAccessed = true;
-        CloseableByteBody body = byteBody;
-        if (body == null) {
+        CloseableByteBody closeableBody = byteBody.get();
+        if (closeableBody == null) {
             synchronized (this) {
-                body = byteBody;
-                if (body == null) {
-                    body = createByteBody();
-                    byteBody = body;
+                closeableBody = byteBody.get();
+                if (closeableBody == null) {
+                    closeableBody = createByteBody();
+                    byteBody.set(closeableBody);
                 }
             }
         }
-        return body;
+        return closeableBody;
     }
 
     @Override
@@ -551,10 +552,10 @@ public class DefaultServletHttpRequest<B> implements
 
     @Override
     public void close() {
-        CloseableByteBody body = byteBody;
+        CloseableByteBody closeableBody = byteBody.get();
         try {
-            if (body != null) {
-                body.close();
+            if (closeableBody != null) {
+                closeableBody.close();
             }
         } finally {
             runDisposalResources();
@@ -616,9 +617,9 @@ public class DefaultServletHttpRequest<B> implements
     }
 
     private void discardByteBodyIfInitialized() {
-        CloseableByteBody body = byteBody;
-        if (body != null) {
-            body.allowDiscard();
+        CloseableByteBody closeableBody = byteBody.get();
+        if (closeableBody != null) {
+            closeableBody.allowDiscard();
         }
     }
 

--- a/test-suite-http-server-tck-jetty/src/test/java/io/micronaut/http/server/tck/jetty/tests/JettyHttpServerTestSuite.java
+++ b/test-suite-http-server-tck-jetty/src/test/java/io/micronaut/http/server/tck/jetty/tests/JettyHttpServerTestSuite.java
@@ -13,7 +13,6 @@ import org.junit.platform.suite.api.SuiteDisplayName;
 @SuiteDisplayName("HTTP Server TCK for Jetty")
 @ExcludeClassNamePatterns({
     "io.micronaut.http.server.tck.tests.FilterProxyTest", // see https://github.com/micronaut-projects/micronaut-core/issues/9725
-    "io.micronaut.http.server.tck.tests.cors.CorsSimpleRequestTest",
     "io.micronaut.http.server.tck.tests.forms.UploadTest", // multipart
     "io.micronaut.http.server.tck.tests.forms.FormBindingDeadlockTest",
 })


### PR DESCRIPTION
## Summary
- re-enable `CorsSimpleRequestTest` in the Jetty TCK suite
- split Jetty-specific unread form-body handling into dedicated Jetty servlet request and handler classes
- keep the generic servlet engine hook overridable instead of using reflection for Jetty request access

## Verification
- `./gradlew :micronaut-http-server-jetty:compileJava`
- `./gradlew :test-suite-http-server-tck-jetty:test --tests '*FormUrlEncodedBodyInRequestFilterTest.bodyParsingInFilter' --tests '*CorsSimpleRequestTest.corsSimpleRequestAllowedForLocalhostAndOriginLocalhost'`

Resolves #929
