### PR TITLE
Add multipart @Body UTF-8 regression test

### DIFF
--- a/http-server-tomcat/src/test/groovy/io/micronaut/servlet/tomcat/TomcatParameterBinding2Spec.groovy
+++ b/http-server-tomcat/src/test/groovy/io/micronaut/servlet/tomcat/TomcatParameterBinding2Spec.groovy
@@ -241,6 +241,22 @@ class TomcatParameterBinding2Spec extends Specification {
         response.body() == 'Good: true'
 
     }
-}
 
+    void "test multipart @Body map uses utf8 for form fields"() {
+
+        given:
+        def value = '“smart quotes” and an em dash —'
+        def request = HttpRequest.POST("/parameters/multipartBodyMap", MultipartBody.builder()
+                .addPart("text", value)
+                .build()
+        )
+        request.contentType(MediaType.MULTIPART_FORM_DATA)
+        def response = client.toBlocking().exchange(request, Argument.STRING, Argument.STRING)
+
+        expect:
+        response.status() == HttpStatus.OK
+        response.body() == value
+
+    }
+}
 

--- a/http-server-tomcat/src/test/java/io/micronaut/servlet/tomcat/ParametersController.java
+++ b/http-server-tomcat/src/test/java/io/micronaut/servlet/tomcat/ParametersController.java
@@ -11,6 +11,8 @@ import io.micronaut.http.cookie.Cookie;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import java.io.*;
+import java.util.List;
+import java.util.Map;
 
 @Controller("/parameters")
 public class ParametersController {
@@ -103,6 +105,11 @@ public class ParametersController {
                 text.equals("Whatever") &&
                 new String(bytes).equals("My Doc") &&
                 IOUtils.readText(new BufferedReader(new InputStreamReader(raw.getInputStream()))).equals("Another Doc"));
+    }
+
+    @Post(value = "/multipartBodyMap", consumes = MediaType.MULTIPART_FORM_DATA, produces = MediaType.TEXT_PLAIN)
+    String multipartBodyMap(@Body Map<String, List<String>> body) {
+        return body.get("text").getFirst();
     }
 
 }


### PR DESCRIPTION
## Summary

- add a Tomcat regression test for multipart `@Body Map<String, List<String>>` binding with UTF-8 form field values
- verify smart quotes and an em dash round-trip without charset corruption

## Tests

- `./gradlew :micronaut-http-server-tomcat:test --tests io.micronaut.servlet.tomcat.TomcatParameterBinding2Spec`

Resolves https://github.com/micronaut-projects/micronaut-servlet/issues/829
