### PR TITLE
Add configurable servlet runtime selection

### DIFF
--- a/http-poja-apache/src/main/java/io/micronaut/http/poja/apache/ApacheRuntimeConfiguration.java
+++ b/http-poja-apache/src/main/java/io/micronaut/http/poja/apache/ApacheRuntimeConfiguration.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2017-2026 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.http.poja.apache;
+
+import io.micronaut.context.annotation.ConfigurationProperties;
+import io.micronaut.core.util.Toggleable;
+
+/**
+ * Enablement configuration for the Apache POJA runtime.
+ */
+@ConfigurationProperties(ApacheRuntimeConfiguration.PREFIX)
+public class ApacheRuntimeConfiguration implements Toggleable {
+
+    public static final String PREFIX = "poja.apache";
+    public static final String ENABLED_PROPERTY = PREFIX + ".enabled";
+
+    private boolean enabled = true;
+
+    @Override
+    public boolean isEnabled() {
+        return enabled;
+    }
+
+    /**
+     * Sets whether the Apache POJA runtime is enabled.
+     *
+     * @param enabled True if the runtime is enabled
+     */
+    public void setEnabled(boolean enabled) {
+        this.enabled = enabled;
+    }
+}

--- a/http-poja-apache/src/main/java/io/micronaut/http/poja/apache/package-info.java
+++ b/http-poja-apache/src/main/java/io/micronaut/http/poja/apache/package-info.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright 2017-2026 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+/**
+ * Apache HTTP POJA runtime integration.
+ */
+@Configuration
+@Requires(property = ApacheRuntimeConfiguration.ENABLED_PROPERTY, value = StringUtils.TRUE, defaultValue = StringUtils.TRUE)
+package io.micronaut.http.poja.apache;
+
+import io.micronaut.context.annotation.Configuration;
+import io.micronaut.context.annotation.Requires;
+import io.micronaut.core.util.StringUtils;

--- a/http-poja-apache/src/test/groovy/io/micronaut/http/poja/ApacheEnablementSpec.groovy
+++ b/http-poja-apache/src/test/groovy/io/micronaut/http/poja/ApacheEnablementSpec.groovy
@@ -1,0 +1,27 @@
+package io.micronaut.http.poja
+
+import io.micronaut.context.ApplicationContext
+import io.micronaut.http.poja.apache.ApacheRuntimeConfiguration
+import io.micronaut.http.poja.apache.ApacheServerlessApplication
+import io.micronaut.runtime.EmbeddedApplication
+import spock.lang.Specification
+
+class ApacheEnablementSpec extends Specification {
+
+    void "apache poja runtime can be disabled"() {
+        given:
+        ApplicationContext context = ApplicationContext.builder()
+            .deduceEnvironment(false)
+            .properties([
+                (ApacheRuntimeConfiguration.ENABLED_PROPERTY): false.toString()
+            ])
+            .start()
+
+        expect:
+        context.findBean(ApacheServerlessApplication).empty
+        context.findBean(EmbeddedApplication).empty
+
+        cleanup:
+        context.close()
+    }
+}

--- a/http-poja-apache/src/test/groovy/io/micronaut/http/poja/ApacheEnablementSpec.groovy
+++ b/http-poja-apache/src/test/groovy/io/micronaut/http/poja/ApacheEnablementSpec.groovy
@@ -8,6 +8,22 @@ import spock.lang.Specification
 
 class ApacheEnablementSpec extends Specification {
 
+    void "apache runtime configuration exposes enablement toggle"() {
+        given:
+        def configuration = new ApacheRuntimeConfiguration()
+
+        expect:
+        configuration.enabled
+        ApacheRuntimeConfiguration.PREFIX == 'poja.apache'
+        ApacheRuntimeConfiguration.ENABLED_PROPERTY == 'poja.apache.enabled'
+
+        when:
+        configuration.enabled = false
+
+        then:
+        !configuration.enabled
+    }
+
     void "apache poja runtime can be disabled"() {
         given:
         ApplicationContext context = ApplicationContext.builder()

--- a/http-poja-common/src/main/java/io/micronaut/http/poja/package-info.java
+++ b/http-poja-common/src/main/java/io/micronaut/http/poja/package-info.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright 2017-2026 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+/**
+ * Common POJA runtime infrastructure.
+ */
+@Configuration
+@Requires(property = "poja.apache.enabled", value = StringUtils.TRUE, defaultValue = StringUtils.TRUE)
+package io.micronaut.http.poja;
+
+import io.micronaut.context.annotation.Configuration;
+import io.micronaut.context.annotation.Requires;
+import io.micronaut.core.util.StringUtils;

--- a/http-server-jdk/src/main/java/io/micronaut/servlet/http/server/jdk/JdkHttpServerConfiguration.java
+++ b/http-server-jdk/src/main/java/io/micronaut/servlet/http/server/jdk/JdkHttpServerConfiguration.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2017-2026 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.servlet.http.server.jdk;
+
+import io.micronaut.context.annotation.ConfigurationProperties;
+import io.micronaut.context.annotation.Replaces;
+import io.micronaut.core.util.Toggleable;
+import io.micronaut.http.server.HttpServerConfiguration;
+
+/**
+ * Configuration for the built-in JDK HTTP server runtime.
+ */
+@ConfigurationProperties("jdk")
+@Replaces(HttpServerConfiguration.class)
+public class JdkHttpServerConfiguration extends HttpServerConfiguration implements Toggleable {
+
+    public static final String PREFIX = HttpServerConfiguration.PREFIX + ".jdk";
+    public static final String ENABLED_PROPERTY = PREFIX + ".enabled";
+
+    private boolean enabled = true;
+
+    @Override
+    public boolean isEnabled() {
+        return enabled;
+    }
+
+    /**
+     * Sets whether the JDK HTTP server runtime is enabled.
+     *
+     * @param enabled True if the runtime is enabled
+     */
+    public void setEnabled(boolean enabled) {
+        this.enabled = enabled;
+    }
+}

--- a/http-server-jdk/src/main/java/io/micronaut/servlet/http/server/jdk/package-info.java
+++ b/http-server-jdk/src/main/java/io/micronaut/servlet/http/server/jdk/package-info.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright 2017-2026 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+/**
+ * Built-in JDK HTTP server runtime integration.
+ */
+@Configuration
+@Requires(property = JdkHttpServerConfiguration.ENABLED_PROPERTY, value = StringUtils.TRUE, defaultValue = StringUtils.TRUE)
+package io.micronaut.servlet.http.server.jdk;
+
+import io.micronaut.context.annotation.Configuration;
+import io.micronaut.context.annotation.Requires;
+import io.micronaut.core.util.StringUtils;

--- a/http-server-jdk/src/test/java/io/micronaut/servlet/http/server/jdk/JdkEnablementTest.java
+++ b/http-server-jdk/src/test/java/io/micronaut/servlet/http/server/jdk/JdkEnablementTest.java
@@ -1,0 +1,26 @@
+package io.micronaut.servlet.http.server.jdk;
+
+import com.sun.net.httpserver.HttpServer;
+import io.micronaut.context.ApplicationContext;
+import io.micronaut.runtime.server.EmbeddedServer;
+import org.junit.jupiter.api.Test;
+
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class JdkEnablementTest {
+
+    @Test
+    void jdkRuntimeCanBeDisabled() {
+        try (ApplicationContext context = ApplicationContext.builder()
+            .deduceEnvironment(false)
+            .properties(Map.of(
+                JdkHttpServerConfiguration.ENABLED_PROPERTY, Boolean.FALSE.toString()
+            ))
+            .start()) {
+            assertTrue(context.findBean(HttpServer.class).isEmpty());
+            assertTrue(context.findBean(EmbeddedServer.class).isEmpty());
+        }
+    }
+}

--- a/http-server-jdk/src/test/java/io/micronaut/servlet/http/server/jdk/JdkEnablementTest.java
+++ b/http-server-jdk/src/test/java/io/micronaut/servlet/http/server/jdk/JdkEnablementTest.java
@@ -12,6 +12,19 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 class JdkEnablementTest {
 
     @Test
+    void jdkRuntimeConfigurationExposesEnablementToggle() {
+        JdkHttpServerConfiguration configuration = new JdkHttpServerConfiguration();
+
+        assertTrue(configuration.isEnabled());
+        assertTrue("micronaut.server.jdk".equals(JdkHttpServerConfiguration.PREFIX));
+        assertTrue("micronaut.server.jdk.enabled".equals(JdkHttpServerConfiguration.ENABLED_PROPERTY));
+
+        configuration.setEnabled(false);
+
+        assertTrue(!configuration.isEnabled());
+    }
+
+    @Test
     void jdkRuntimeCanBeDisabled() {
         try (ApplicationContext context = ApplicationContext.builder()
             .deduceEnvironment(false)

--- a/http-server-jetty/src/main/java/io/micronaut/servlet/jetty/JettyConfiguration.java
+++ b/http-server-jetty/src/main/java/io/micronaut/servlet/jetty/JettyConfiguration.java
@@ -49,13 +49,17 @@ import org.eclipse.jetty.server.ServerConnector;
  */
 @ConfigurationProperties("jetty")
 @Replaces(HttpServerConfiguration.class)
-public class JettyConfiguration extends HttpServerConfiguration {
+public class JettyConfiguration extends HttpServerConfiguration implements Toggleable {
+
+    public static final String PREFIX = HttpServerConfiguration.PREFIX + ".jetty";
+    public static final String ENABLED_PROPERTY = PREFIX + ".enabled";
 
     @ConfigurationBuilder
     protected HttpConfiguration httpConfiguration = new HttpConfiguration();
     private final JettyRequestLog requestLog;
 
     private final MultipartConfiguration multipartConfiguration;
+    private boolean enabled = true;
     private Map<String, String> initParameters;
 
     /**
@@ -96,6 +100,20 @@ public class JettyConfiguration extends HttpServerConfiguration {
      */
     public Optional<JettyRequestLog> getRequestLog() {
         return Optional.ofNullable(requestLog);
+    }
+
+    @Override
+    public boolean isEnabled() {
+        return enabled;
+    }
+
+    /**
+     * Sets whether the Jetty runtime is enabled.
+     *
+     * @param enabled True if the runtime is enabled
+     */
+    public void setEnabled(boolean enabled) {
+        this.enabled = enabled;
     }
 
     /**

--- a/http-server-jetty/src/main/java/io/micronaut/servlet/jetty/package-info.java
+++ b/http-server-jetty/src/main/java/io/micronaut/servlet/jetty/package-info.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright 2017-2026 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+/**
+ * Jetty runtime integration.
+ */
+@Configuration
+@Requires(property = JettyConfiguration.ENABLED_PROPERTY, value = StringUtils.TRUE, defaultValue = StringUtils.TRUE)
+package io.micronaut.servlet.jetty;
+
+import io.micronaut.context.annotation.Configuration;
+import io.micronaut.context.annotation.Requires;
+import io.micronaut.core.util.StringUtils;

--- a/http-server-jetty/src/test/groovy/io/micronaut/servlet/jetty/JettyEnablementSpec.groovy
+++ b/http-server-jetty/src/test/groovy/io/micronaut/servlet/jetty/JettyEnablementSpec.groovy
@@ -7,6 +7,22 @@ import spock.lang.Specification
 
 class JettyEnablementSpec extends Specification {
 
+    void "jetty configuration exposes enablement toggle"() {
+        given:
+        def configuration = new JettyConfiguration(null, null)
+
+        expect:
+        configuration.enabled
+        JettyConfiguration.PREFIX == 'micronaut.server.jetty'
+        JettyConfiguration.ENABLED_PROPERTY == 'micronaut.server.jetty.enabled'
+
+        when:
+        configuration.enabled = false
+
+        then:
+        !configuration.enabled
+    }
+
     void "jetty runtime can be disabled"() {
         given:
         ApplicationContext context = ApplicationContext.builder()

--- a/http-server-jetty/src/test/groovy/io/micronaut/servlet/jetty/JettyEnablementSpec.groovy
+++ b/http-server-jetty/src/test/groovy/io/micronaut/servlet/jetty/JettyEnablementSpec.groovy
@@ -1,0 +1,27 @@
+package io.micronaut.servlet.jetty
+
+import io.micronaut.context.ApplicationContext
+import io.micronaut.runtime.server.EmbeddedServer
+import org.eclipse.jetty.server.Server
+import spock.lang.Specification
+
+class JettyEnablementSpec extends Specification {
+
+    void "jetty runtime can be disabled"() {
+        given:
+        ApplicationContext context = ApplicationContext.builder()
+            .deduceEnvironment(false)
+            .properties([
+                (JettyConfiguration.ENABLED_PROPERTY): false.toString()
+            ])
+            .start()
+
+        expect:
+        context.findBean(Server).empty
+        context.findBean(JettyServer).empty
+        context.findBean(EmbeddedServer).empty
+
+        cleanup:
+        context.close()
+    }
+}

--- a/http-server-tomcat/src/main/java/io/micronaut/servlet/tomcat/TomcatConfiguration.java
+++ b/http-server-tomcat/src/main/java/io/micronaut/servlet/tomcat/TomcatConfiguration.java
@@ -52,11 +52,15 @@ import org.apache.coyote.http2.Http2Protocol;
         AjpNioProtocol.class
 })
 @Replaces(HttpServerConfiguration.class)
-public class TomcatConfiguration extends HttpServerConfiguration {
+public class TomcatConfiguration extends HttpServerConfiguration implements Toggleable {
+
+    public static final String PREFIX = HttpServerConfiguration.PREFIX + ".tomcat";
+    public static final String ENABLED_PROPERTY = PREFIX + ".enabled";
 
     @ConfigurationBuilder
     protected final Connector tomcatConnector;
     private final MultipartConfiguration multipartConfiguration;
+    private boolean enabled = true;
     private String protocol;
 
     private AccessLogConfiguration accessLogConfiguration;
@@ -102,6 +106,20 @@ public class TomcatConfiguration extends HttpServerConfiguration {
      */
     public Optional<MultipartConfiguration> getMultipartConfiguration() {
         return Optional.ofNullable(multipartConfiguration);
+    }
+
+    @Override
+    public boolean isEnabled() {
+        return enabled;
+    }
+
+    /**
+     * Sets whether the Tomcat runtime is enabled.
+     *
+     * @param enabled True if the runtime is enabled
+     */
+    public void setEnabled(boolean enabled) {
+        this.enabled = enabled;
     }
 
     /**

--- a/http-server-tomcat/src/main/java/io/micronaut/servlet/tomcat/package-info.java
+++ b/http-server-tomcat/src/main/java/io/micronaut/servlet/tomcat/package-info.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright 2017-2026 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+/**
+ * Tomcat runtime integration.
+ */
+@Configuration
+@Requires(property = TomcatConfiguration.ENABLED_PROPERTY, value = StringUtils.TRUE, defaultValue = StringUtils.TRUE)
+package io.micronaut.servlet.tomcat;
+
+import io.micronaut.context.annotation.Configuration;
+import io.micronaut.context.annotation.Requires;
+import io.micronaut.core.util.StringUtils;

--- a/http-server-tomcat/src/test/groovy/io/micronaut/servlet/tomcat/TomcatEnablementSpec.groovy
+++ b/http-server-tomcat/src/test/groovy/io/micronaut/servlet/tomcat/TomcatEnablementSpec.groovy
@@ -1,0 +1,27 @@
+package io.micronaut.servlet.tomcat
+
+import io.micronaut.context.ApplicationContext
+import io.micronaut.runtime.server.EmbeddedServer
+import org.apache.catalina.startup.Tomcat
+import spock.lang.Specification
+
+class TomcatEnablementSpec extends Specification {
+
+    void "tomcat runtime can be disabled"() {
+        given:
+        ApplicationContext context = ApplicationContext.builder()
+            .deduceEnvironment(false)
+            .properties([
+                (TomcatConfiguration.ENABLED_PROPERTY): false.toString()
+            ])
+            .start()
+
+        expect:
+        context.findBean(Tomcat).empty
+        context.findBean(TomcatServer).empty
+        context.findBean(EmbeddedServer).empty
+
+        cleanup:
+        context.close()
+    }
+}

--- a/http-server-tomcat/src/test/groovy/io/micronaut/servlet/tomcat/TomcatEnablementSpec.groovy
+++ b/http-server-tomcat/src/test/groovy/io/micronaut/servlet/tomcat/TomcatEnablementSpec.groovy
@@ -7,6 +7,22 @@ import spock.lang.Specification
 
 class TomcatEnablementSpec extends Specification {
 
+    void "tomcat configuration exposes enablement toggle"() {
+        given:
+        def configuration = new TomcatConfiguration(null, null)
+
+        expect:
+        configuration.enabled
+        TomcatConfiguration.PREFIX == 'micronaut.server.tomcat'
+        TomcatConfiguration.ENABLED_PROPERTY == 'micronaut.server.tomcat.enabled'
+
+        when:
+        configuration.enabled = false
+
+        then:
+        !configuration.enabled
+    }
+
     void "tomcat runtime can be disabled"() {
         given:
         ApplicationContext context = ApplicationContext.builder()

--- a/http-server-undertow/src/main/java/io/micronaut/servlet/undertow/UndertowConfiguration.java
+++ b/http-server-undertow/src/main/java/io/micronaut/servlet/undertow/UndertowConfiguration.java
@@ -49,13 +49,17 @@ import java.util.concurrent.ExecutorService;
     accessType = TypeHint.AccessType.ALL_DECLARED_FIELDS
 )
 @Replaces(HttpServerConfiguration.class)
-public class UndertowConfiguration extends HttpServerConfiguration {
+public class UndertowConfiguration extends HttpServerConfiguration implements Toggleable {
+
+    public static final String PREFIX = HttpServerConfiguration.PREFIX + ".undertow";
+    public static final String ENABLED_PROPERTY = PREFIX + ".enabled";
 
     @ConfigurationBuilder
     protected Undertow.Builder undertowBuilder = Undertow.builder();
 
     private final MultipartConfiguration multipartConfiguration;
     private AccessLogConfiguration accessLogConfiguration;
+    private boolean enabled = true;
     private Map<String, String> workerOptions = new HashMap<>(5);
     private Map<String, String> socketOptions = new HashMap<>(5);
     private Map<String, String> serverOptions = new HashMap<>(5);
@@ -74,6 +78,20 @@ public class UndertowConfiguration extends HttpServerConfiguration {
      */
     public Optional<AccessLogConfiguration> getAccessLogConfiguration() {
         return Optional.ofNullable(accessLogConfiguration);
+    }
+
+    @Override
+    public boolean isEnabled() {
+        return enabled;
+    }
+
+    /**
+     * Sets whether the Undertow runtime is enabled.
+     *
+     * @param enabled True if the runtime is enabled
+     */
+    public void setEnabled(boolean enabled) {
+        this.enabled = enabled;
     }
 
     /**

--- a/http-server-undertow/src/main/java/io/micronaut/servlet/undertow/package-info.java
+++ b/http-server-undertow/src/main/java/io/micronaut/servlet/undertow/package-info.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright 2017-2026 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+/**
+ * Undertow runtime integration.
+ */
+@Configuration
+@Requires(property = UndertowConfiguration.ENABLED_PROPERTY, value = StringUtils.TRUE, defaultValue = StringUtils.TRUE)
+package io.micronaut.servlet.undertow;
+
+import io.micronaut.context.annotation.Configuration;
+import io.micronaut.context.annotation.Requires;
+import io.micronaut.core.util.StringUtils;

--- a/http-server-undertow/src/test/groovy/io/micronaut/servlet/undertow/UndertowEnablementSpec.groovy
+++ b/http-server-undertow/src/test/groovy/io/micronaut/servlet/undertow/UndertowEnablementSpec.groovy
@@ -7,6 +7,22 @@ import spock.lang.Specification
 
 class UndertowEnablementSpec extends Specification {
 
+    void "undertow configuration exposes enablement toggle"() {
+        given:
+        def configuration = new UndertowConfiguration(null)
+
+        expect:
+        configuration.enabled
+        UndertowConfiguration.PREFIX == 'micronaut.server.undertow'
+        UndertowConfiguration.ENABLED_PROPERTY == 'micronaut.server.undertow.enabled'
+
+        when:
+        configuration.enabled = false
+
+        then:
+        !configuration.enabled
+    }
+
     void "undertow runtime can be disabled"() {
         given:
         ApplicationContext context = ApplicationContext.builder()

--- a/http-server-undertow/src/test/groovy/io/micronaut/servlet/undertow/UndertowEnablementSpec.groovy
+++ b/http-server-undertow/src/test/groovy/io/micronaut/servlet/undertow/UndertowEnablementSpec.groovy
@@ -1,0 +1,27 @@
+package io.micronaut.servlet.undertow
+
+import io.micronaut.context.ApplicationContext
+import io.micronaut.runtime.server.EmbeddedServer
+import io.undertow.Undertow
+import spock.lang.Specification
+
+class UndertowEnablementSpec extends Specification {
+
+    void "undertow runtime can be disabled"() {
+        given:
+        ApplicationContext context = ApplicationContext.builder()
+            .deduceEnvironment(false)
+            .properties([
+                (UndertowConfiguration.ENABLED_PROPERTY): false.toString()
+            ])
+            .start()
+
+        expect:
+        context.findBean(Undertow).empty
+        context.findBean(UndertowServer).empty
+        context.findBean(EmbeddedServer).empty
+
+        cleanup:
+        context.close()
+    }
+}

--- a/servlet-core/src/main/java/io/micronaut/servlet/http/server/HttpServerEmbeddedServer.java
+++ b/servlet-core/src/main/java/io/micronaut/servlet/http/server/HttpServerEmbeddedServer.java
@@ -39,6 +39,7 @@ import java.util.concurrent.atomic.AtomicBoolean;
 
 @Internal
 @Experimental
+@Requires(property = "micronaut.server.jdk.enabled", value = "true", defaultValue = "true")
 @Requires(beans = HttpServer.class)
 @Singleton
 class HttpServerEmbeddedServer extends AbstractServletServer<HttpServer> {

--- a/servlet-core/src/main/java/io/micronaut/servlet/http/server/HttpServerFactory.java
+++ b/servlet-core/src/main/java/io/micronaut/servlet/http/server/HttpServerFactory.java
@@ -34,6 +34,7 @@ import java.util.List;
 @Experimental
 @Internal
 @Factory
+@Requires(property = "micronaut.server.jdk.enabled", value = "true", defaultValue = "true")
 public class HttpServerFactory {
     /**
      *

--- a/servlet-core/src/main/java/io/micronaut/servlet/http/server/RootHttpHandlerPath.java
+++ b/servlet-core/src/main/java/io/micronaut/servlet/http/server/RootHttpHandlerPath.java
@@ -22,6 +22,7 @@ import jakarta.inject.Singleton;
 /**
  * A {@link HttpHandlerPath} for the path {@value /}.
  */
+@Requires(property = "micronaut.server.jdk.enabled", value = "true", defaultValue = "true")
 @Requires(beans = HttpHandler.class)
 @Requires(missingBeans = HttpHandlerPath.class)
 @Singleton

--- a/servlet-engine/src/main/java/io/micronaut/servlet/engine/bind/DefaultServletBinderRegistry.java
+++ b/servlet-engine/src/main/java/io/micronaut/servlet/engine/bind/DefaultServletBinderRegistry.java
@@ -17,6 +17,7 @@ package io.micronaut.servlet.engine.bind;
 
 import io.micronaut.context.BeanProvider;
 import io.micronaut.context.annotation.Replaces;
+import io.micronaut.context.annotation.Secondary;
 import io.micronaut.core.annotation.Internal;
 import io.micronaut.core.convert.ArgumentConversionContext;
 import io.micronaut.core.convert.ConversionService;
@@ -49,6 +50,7 @@ import java.util.List;
  * @since 1.0.0
  */
 @Singleton
+@Secondary
 @Replaces(DefaultRequestBinderRegistry.class)
 @Internal
 class DefaultServletBinderRegistry<T> extends ServletBinderRegistry<T> {

--- a/src/main/docs/guide/httpPoja.adoc
+++ b/src/main/docs/guide/httpPoja.adoc
@@ -12,6 +12,16 @@ dependency:io.micronaut.servlet:micronaut-http-poja-test[scope="test"]
 To customize the HTTP POJA you can use the following configuration properties:
 
 include::{includedir}configurationProperties/io.micronaut.http.poja.apache.ApacheServletConfiguration.adoc[]
+include::{includedir}configurationProperties/io.micronaut.http.poja.apache.ApacheRuntimeConfiguration.adoc[]
+
+To disable the Apache HTTP POJA runtime when it is present on the classpath:
+
+[configuration]
+----
+poja.apache.enabled: false
+----
+
+This is useful when multiple Micronaut runtimes are available and you want Micronaut to ignore the POJA runtime during startup.
 
 === Use HTTP POJA with launchd on MacOS
 
@@ -159,4 +169,3 @@ In a separate terminal send a request to the socket:
 ----
 curl --unix-socket /tmp/http-poja.sock http://localhost/
 ----
-

--- a/src/main/docs/guide/httpServer.adoc
+++ b/src/main/docs/guide/httpServer.adoc
@@ -1,3 +1,14 @@
 To use a server runtime based on the https://docs.oracle.com/javase/8/docs/jre/api/net/httpserver/spec/com/sun/net/httpserver/HttpServer.html[Java built-in Http Server], add the following dependency:
 
 dependency:micronaut-http-server-jdk[groupId=io.micronaut.servlet]
+
+To customize the built-in JDK HTTP server runtime you can use the following configuration properties:
+
+include::{includedir}configurationProperties/io.micronaut.servlet.http.server.jdk.JdkHttpServerConfiguration.adoc[]
+
+To disable the built-in JDK HTTP server runtime when it is present on the classpath:
+
+[configuration]
+----
+micronaut.server.jdk.enabled: false
+----

--- a/src/main/docs/guide/jetty.adoc
+++ b/src/main/docs/guide/jetty.adoc
@@ -10,6 +10,14 @@ To customize the Jetty server you can use the following configuration properties
 
 include::{includedir}configurationProperties/io.micronaut.servlet.jetty.JettyConfiguration.adoc[]
 
+To disable the Jetty runtime when it is present on the classpath:
+
+[configuration]
+----
+micronaut.server.jetty.enabled: false
+----
+
+This is useful when multiple servlet runtimes are available and you want Micronaut to ignore Jetty during startup.
 
 Or you can register a `BeanCreatedEventListener`:
 

--- a/src/main/docs/guide/tomcat.adoc
+++ b/src/main/docs/guide/tomcat.adoc
@@ -10,6 +10,14 @@ To customize the Tomcat server you can use the following configuration propertie
 
 include::{includedir}configurationProperties/io.micronaut.servlet.tomcat.TomcatConfiguration.adoc[]
 
+To disable the Tomcat runtime when it is present on the classpath:
+
+[configuration]
+----
+micronaut.server.tomcat.enabled: false
+----
+
+This is useful when multiple servlet runtimes are available and you want Micronaut to ignore Tomcat during startup.
 
 Or you can register a `BeanCreatedEventListener`:
 

--- a/src/main/docs/guide/undertow.adoc
+++ b/src/main/docs/guide/undertow.adoc
@@ -10,6 +10,14 @@ To customize the Undertow server you can use the following configuration propert
 
 include::{includedir}configurationProperties/io.micronaut.servlet.undertow.UndertowConfiguration.adoc[]
 
+To disable the Undertow runtime when it is present on the classpath:
+
+[configuration]
+----
+micronaut.server.undertow.enabled: false
+----
+
+This is useful when multiple servlet runtimes are available and you want Micronaut to ignore Undertow during startup.
 
 Or you can register a `BeanCreatedEventListener`:
 

--- a/test-sample-poja/build.gradle
+++ b/test-sample-poja/build.gradle
@@ -26,6 +26,7 @@ dependencies {
     annotationProcessor(mn.micronaut.inject.java)
 
     testImplementation(projects.micronautHttpPojaTest)
+    testImplementation(projects.micronautHttpServerJetty)
     testImplementation(mnTest.micronaut.test.junit5)
     testImplementation(mn.micronaut.http.client)
 

--- a/test-sample-poja/src/test/java/io/micronaut/http/poja/sample/RuntimeSelectionTest.java
+++ b/test-sample-poja/src/test/java/io/micronaut/http/poja/sample/RuntimeSelectionTest.java
@@ -1,0 +1,44 @@
+package io.micronaut.http.poja.sample;
+
+import io.micronaut.context.ApplicationContext;
+import io.micronaut.http.poja.apache.ApacheServerlessApplication;
+import io.micronaut.runtime.EmbeddedApplication;
+import io.micronaut.servlet.jetty.JettyServer;
+import org.junit.jupiter.api.Test;
+
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+
+class RuntimeSelectionTest {
+    private static final String JDK_ENABLED_PROPERTY = "micronaut.server.jdk.enabled";
+
+    @Test
+    void selectsPojaWhenJettyIsDisabled() {
+        try (ApplicationContext context = ApplicationContext.builder()
+            .deduceEnvironment(false)
+            .properties(Map.of(
+                "micronaut.server.jetty.enabled", Boolean.FALSE.toString(),
+                JDK_ENABLED_PROPERTY, Boolean.FALSE.toString()
+            ))
+            .start()) {
+            EmbeddedApplication<?> embeddedApplication = context.getBean(EmbeddedApplication.class);
+            assertInstanceOf(ApacheServerlessApplication.class, embeddedApplication);
+        }
+    }
+
+    @Test
+    void selectsJettyWhenPojaIsDisabled() {
+        try (ApplicationContext context = ApplicationContext.builder()
+            .deduceEnvironment(false)
+            .properties(Map.of(
+                "poja.apache.enabled", Boolean.FALSE.toString(),
+                "micronaut.server.jetty.enabled", Boolean.TRUE.toString(),
+                JDK_ENABLED_PROPERTY, Boolean.FALSE.toString()
+            ))
+            .start()) {
+            EmbeddedApplication<?> embeddedApplication = context.getBean(EmbeddedApplication.class);
+            assertInstanceOf(JettyServer.class, embeddedApplication);
+        }
+    }
+}

--- a/test-sample-poja/src/test/resources/application-test.yml
+++ b/test-sample-poja/src/test/resources/application-test.yml
@@ -1,0 +1,4 @@
+micronaut:
+  server:
+    jetty:
+      enabled: false


### PR DESCRIPTION
## Summary
- add runtime enablement properties for servlet runtimes so applications can defer runtime selection until startup
- cover Apache POJA, JDK HTTP server, Jetty, Tomcat, and Undertow runtime selection with tests
- document runtime selection and configuration across the servlet guides

## Verification
- approved local task changes

Resolves https://github.com/micronaut-projects/micronaut-servlet/issues/1061
