### PR TITLE
Fix FilterProxyTest TCK test

### DIFF
--- a/servlet-core/build.gradle.kts
+++ b/servlet-core/build.gradle.kts
@@ -4,6 +4,7 @@ plugins {
 
 dependencies {
     api(mn.micronaut.http.server)
+    implementation(mn.micronaut.http.netty)
     compileOnly(mn.micronaut.discovery.core)
     compileOnly(mn.micronaut.json.core)
     implementation(mn.micronaut.router)

--- a/servlet-core/src/main/java/io/micronaut/servlet/http/ServletHttpHandler.java
+++ b/servlet-core/src/main/java/io/micronaut/servlet/http/ServletHttpHandler.java
@@ -22,9 +22,11 @@ import org.jspecify.annotations.Nullable;
 import io.micronaut.core.convert.ConversionService;
 import io.micronaut.core.execution.ExecutionFlow;
 import io.micronaut.core.io.buffer.ByteArrayBufferFactory;
+import io.micronaut.core.io.buffer.ReadBufferFactory;
 import io.micronaut.core.propagation.PropagatedContext;
 import io.micronaut.core.util.SupplierUtil;
 import io.micronaut.http.ByteBodyHttpResponse;
+import io.micronaut.http.ByteBodyHttpResponseWrapper;
 import io.micronaut.http.HttpHeaders;
 import io.micronaut.http.HttpRequest;
 import io.micronaut.http.HttpResponse;
@@ -32,11 +34,14 @@ import io.micronaut.http.HttpStatus;
 import io.micronaut.http.MutableHttpHeaders;
 import io.micronaut.http.body.AvailableByteBody;
 import io.micronaut.http.body.ByteBodyFactory;
+import io.micronaut.http.body.CloseableByteBody;
 import io.micronaut.http.body.MessageBodyHandlerRegistry;
 import io.micronaut.http.context.ServerHttpRequestContext;
 import io.micronaut.http.context.event.HttpRequestReceivedEvent;
 import io.micronaut.http.context.event.HttpRequestTerminatedEvent;
 import io.micronaut.http.exceptions.HttpStatusException;
+import io.micronaut.http.netty.NettyHttpResponseBuilder;
+import io.micronaut.http.netty.stream.StreamedHttpResponse;
 import io.micronaut.http.server.RequestLifecycle;
 import io.micronaut.http.server.ResponseLifecycle;
 import io.micronaut.http.server.RouteExecutor;
@@ -46,8 +51,11 @@ import io.micronaut.http.server.types.files.SystemFile;
 import io.micronaut.inject.qualifiers.Qualifiers;
 import io.micronaut.scheduling.TaskExecutors;
 import io.micronaut.web.router.resource.StaticResourceResolver;
+import io.netty.handler.codec.http.HttpContent;
+import io.netty.util.ReferenceCountUtil;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import reactor.core.publisher.Flux;
 
 import java.io.EOFException;
 import java.io.File;
@@ -74,6 +82,8 @@ import java.util.function.Supplier;
  * @since 1.2.0
  */
 public abstract class ServletHttpHandler<REQ, RES> implements AutoCloseable, LifeCycle<ServletHttpHandler<REQ, RES>> {
+    private static final ByteBodyFactory STREAMING_BODY_FACTORY = ByteBodyFactory.createDefault(ByteArrayBufferFactory.INSTANCE);
+
     /**
      * Logger to be used by subclasses for logging.
      */
@@ -301,7 +311,31 @@ public abstract class ServletHttpHandler<REQ, RES> implements AutoCloseable, Lif
         if (shr.isCommitted()) {
             return ExecutionFlow.just(new ExecutionResult(null));
         }
+        ByteBodyHttpResponse<?> proxied = adaptNettyStreamingResponse(response);
+        if (proxied != null) {
+            return ExecutionFlow.just(new ExecutionResult(proxied));
+        }
         return new ServletResponseLifecycle().encodeHttpResponseSafe(req, response).map(ExecutionResult::new);
+    }
+
+    private @Nullable ByteBodyHttpResponse<?> adaptNettyStreamingResponse(HttpResponse<?> response) {
+        if (!(response instanceof NettyHttpResponseBuilder builder) || !builder.isStream()) {
+            return null;
+        }
+        StreamedHttpResponse streamedResponse = builder.toStreamHttpResponse();
+        CloseableByteBody byteBody = STREAMING_BODY_FACTORY.adapt(
+            Flux.from(streamedResponse)
+                .doOnDiscard(HttpContent.class, ReferenceCountUtil::release)
+                .map(content -> {
+                    try {
+                        return ReadBufferFactory.getJdkFactory().copyOf(content.content().nioBuffer());
+                    } finally {
+                        ReferenceCountUtil.release(content);
+                    }
+                }),
+            response.getHeaders().contentLength()
+        );
+        return ByteBodyHttpResponseWrapper.wrap(response, byteBody);
     }
 
     private static void handleFallback(ServletHttpResponse<?, ?> shr, Throwable t) {

--- a/test-suite-http-server-tck-jdk/src/test/java/io/micronaut/servlet/http/server/jdk/tests/HttpServerEmbeddedServerSuite.java
+++ b/test-suite-http-server-tck-jdk/src/test/java/io/micronaut/servlet/http/server/jdk/tests/HttpServerEmbeddedServerSuite.java
@@ -11,7 +11,7 @@ import org.junit.platform.suite.api.SuiteDisplayName;
 })
 @SuiteDisplayName("TCK for Built-in Java HTTP Server")
 @ExcludeClassNamePatterns({
-    "io.micronaut.http.server.tck.tests.FilterProxyTest", // see https://github.com/micronaut-projects/micronaut-core/issues/9725
+    "io.micronaut.http.server.tck.tests.FilterProxyTest", // times out on self-proxying requests
     "io.micronaut.http.server.tck.tests.forms.UploadTest", // multipart
     "io.micronaut.http.server.tck.tests.forms.FormBindingDeadlockTest",
 })

--- a/test-suite-http-server-tck-jetty/src/test/java/io/micronaut/http/server/tck/jetty/tests/JettyHttpServerTestSuite.java
+++ b/test-suite-http-server-tck-jetty/src/test/java/io/micronaut/http/server/tck/jetty/tests/JettyHttpServerTestSuite.java
@@ -12,7 +12,6 @@ import org.junit.platform.suite.api.SuiteDisplayName;
 })
 @SuiteDisplayName("HTTP Server TCK for Jetty")
 @ExcludeClassNamePatterns({
-    "io.micronaut.http.server.tck.tests.FilterProxyTest", // see https://github.com/micronaut-projects/micronaut-core/issues/9725
     "io.micronaut.http.server.tck.tests.cors.CorsSimpleRequestTest",
     "io.micronaut.http.server.tck.tests.forms.UploadTest", // multipart
     "io.micronaut.http.server.tck.tests.forms.FormBindingDeadlockTest",

--- a/test-suite-http-server-tck-tomcat/src/test/java/io/micronaut/http/server/tck/tomcat/tests/TomcatHttpServerTestSuite.java
+++ b/test-suite-http-server-tck-tomcat/src/test/java/io/micronaut/http/server/tck/tomcat/tests/TomcatHttpServerTestSuite.java
@@ -9,7 +9,6 @@ import org.junit.platform.suite.api.SuiteDisplayName;
 @SelectPackages("io.micronaut.http.server.tck.tests")
 @SuiteDisplayName("HTTP Server TCK for Tomcat")
 @ExcludeClassNamePatterns({
-    "io.micronaut.http.server.tck.tests.FilterProxyTest", // see https://github.com/micronaut-projects/micronaut-core/issues/9725
     "io.micronaut.http.server.tck.tests.forms.UploadTest", // multipart
     "io.micronaut.http.server.tck.tests.forms.FormBindingDeadlockTest",
 })

--- a/test-suite-http-server-tck-undertow/src/test/java/io/micronaut/http/server/tck/undertow/tests/UndertowHttpServerTestSuite.java
+++ b/test-suite-http-server-tck-undertow/src/test/java/io/micronaut/http/server/tck/undertow/tests/UndertowHttpServerTestSuite.java
@@ -10,7 +10,6 @@ import org.junit.platform.suite.api.SuiteDisplayName;
 @SuiteDisplayName("HTTP Server TCK for Undertow")
 @ExcludeClassNamePatterns({
     "io.micronaut.http.server.tck.tests.RemoteAddressTest", // Undertow.getHost() reports an ipv6 address, not 127.0.0.1
-    "io.micronaut.http.server.tck.tests.FilterProxyTest", // see https://github.com/micronaut-projects/micronaut-core/issues/9725
     "io.micronaut.http.server.tck.tests.forms.UploadTest", // multipart
     "io.micronaut.http.server.tck.tests.forms.FormBindingDeadlockTest",
 })


### PR DESCRIPTION
## Summary
- bridge streamed Netty proxy responses into a servlet ByteBody before generic encoding drops the body
- re-enable FilterProxyTest in the Tomcat, Jetty, and Undertow TCK suites
- keep the JDK suite excluded because self-proxying requests still time out there

## Verification
- ./gradlew spotlessApply :test-suite-http-server-tck-tomcat:test --tests io.micronaut.http.server.tck.tomcat.tests.TomcatHttpServerTestSuite :test-suite-http-server-tck-jetty:test --tests io.micronaut.http.server.tck.jetty.tests.JettyHttpServerTestSuite :test-suite-http-server-tck-undertow:test --tests io.micronaut.http.server.tck.undertow.tests.UndertowHttpServerTestSuite

Resolves #543
