### PR TITLE
Document Payara deployment workaround

### DIFF
--- a/src/main/docs/guide/knownIssues.adoc
+++ b/src/main/docs/guide/knownIssues.adoc
@@ -1,5 +1,13 @@
 There are some known issues with Servlet integration to the Micronaut Framework
 
+=== Payara deployment annotation scanning
+
+Payara may scan Micronaut libraries in a WAR for Jakarta lifecycle annotations before Micronaut starts.
+When that happens, deployment can fail on internal Micronaut classes such as `DefaultWatchThread`.
+
+Add an application `src/main/webapp/WEB-INF/web.xml` with `metadata-complete="true"` as described in the
+xref:warDeployment/payara.adoc[Payara deployment] section.
+
 === HttpProxyClient and Server Filters
 
 It is not currently possible to use the HttpProxyClient with Servlet Filters.
@@ -8,4 +16,3 @@ It is not currently possible to use the HttpProxyClient with Servlet Filters.
 
 Local error handlers that require the request body to be reparsed will not work in Servlet based applications.
 The body is read from the request input-stream and so attempting to reparse it for the error handler will fail.
-

--- a/src/main/docs/guide/toc.yml
+++ b/src/main/docs/guide/toc.yml
@@ -5,6 +5,7 @@ servletAnnotation: Servlet Annotation Support
 warDeployment:
   title: WAR Deployment
   versioning: Container version considerations
+  payara: Payara deployment
   externalConfig: External Configuration
   warContext: WAR Context path
 jetty: Jetty Server

--- a/src/main/docs/guide/warDeployment/payara.adoc
+++ b/src/main/docs/guide/warDeployment/payara.adoc
@@ -1,0 +1,23 @@
+Payara scans application classes and libraries for Jakarta lifecycle annotations during deployment.
+Micronaut applications packaged as WAR files include internal lifecycle beans from Micronaut Context, for example
+`io.micronaut.scheduling.io.watch.DefaultWatchThread`, and Payara can reject those classes before Micronaut starts.
+
+For Micronaut 4 and later, only Payara 6 or later is supported because Micronaut uses the `jakarta.servlet` API.
+
+When deploying to Payara, add an application `web.xml` with `metadata-complete="true"` so the container does not try
+to discover lifecycle annotations from Micronaut libraries:
+
+[source,xml]
+.src/main/webapp/WEB-INF/web.xml
+----
+<?xml version="1.0" encoding="UTF-8"?>
+<web-app xmlns="https://jakarta.ee/xml/ns/jakartaee"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="https://jakarta.ee/xml/ns/jakartaee https://jakarta.ee/xml/ns/jakartaee/web-app_6_0.xsd"
+         version="6.0"
+         metadata-complete="true">
+</web-app>
+----
+
+This deployment descriptor complements the `web-fragment.xml` packaged in `micronaut-servlet-engine` and prevents
+Payara from treating Micronaut internal lifecycle methods as container lifecycle callbacks.


### PR DESCRIPTION
## Summary
- document the Payara lifecycle annotation scanning failure for Micronaut WAR deployments
- add a dedicated Payara deployment guide with a `web.xml` example using `metadata-complete="true"`
- link the workaround from the known issues guide

## Notes
- documentation-only change

Resolves #756
