### PR TITLE
Use current thread for POJA blocking work

### DIFF
--- a/http-poja-apache/src/main/java/io/micronaut/http/poja/apache/ApacheExecutorServiceFactory.java
+++ b/http-poja-apache/src/main/java/io/micronaut/http/poja/apache/ApacheExecutorServiceFactory.java
@@ -37,7 +37,7 @@ final class ApacheExecutorServiceFactory {
     @Singleton
     @Named(TaskExecutors.BLOCKING)
     @Replaces(value = ExecutorService.class, factory = IOExecutorServiceConfig.class, named = TaskExecutors.BLOCKING)
-    @Requires(missingProperty = ExecutorConfiguration.PREFIX + "." + TaskExecutors.BLOCKING)
+    @Requires(missingProperty = ExecutorConfiguration.PREFIX + "." + TaskExecutors.BLOCKING + ".type")
     ExecutorService blocking() {
         return new CurrentThreadExecutorService();
     }

--- a/http-poja-apache/src/main/java/io/micronaut/http/poja/apache/ApacheExecutorServiceFactory.java
+++ b/http-poja-apache/src/main/java/io/micronaut/http/poja/apache/ApacheExecutorServiceFactory.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2017-2026 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.http.poja.apache;
+
+import io.micronaut.context.annotation.Factory;
+import io.micronaut.context.annotation.Replaces;
+import io.micronaut.context.annotation.Requires;
+import io.micronaut.core.util.StringUtils;
+import io.micronaut.scheduling.TaskExecutors;
+import io.micronaut.scheduling.executor.ExecutorConfiguration;
+import io.micronaut.scheduling.executor.IOExecutorServiceConfig;
+import jakarta.inject.Named;
+import jakarta.inject.Singleton;
+
+import java.util.concurrent.ExecutorService;
+
+/**
+ * Configures POJA to keep blocking work on the request thread by default.
+ */
+@Factory
+@Requires(property = ApacheRuntimeConfiguration.ENABLED_PROPERTY, value = StringUtils.TRUE, defaultValue = StringUtils.TRUE)
+final class ApacheExecutorServiceFactory {
+
+    @Singleton
+    @Named(TaskExecutors.BLOCKING)
+    @Replaces(value = ExecutorService.class, factory = IOExecutorServiceConfig.class, named = TaskExecutors.BLOCKING)
+    @Requires(missingProperty = ExecutorConfiguration.PREFIX + "." + TaskExecutors.BLOCKING)
+    ExecutorService blocking() {
+        return new CurrentThreadExecutorService();
+    }
+}

--- a/http-poja-apache/src/main/java/io/micronaut/http/poja/apache/CurrentThreadExecutorService.java
+++ b/http-poja-apache/src/main/java/io/micronaut/http/poja/apache/CurrentThreadExecutorService.java
@@ -54,7 +54,7 @@ final class CurrentThreadExecutorService extends AbstractExecutorService {
 
     @Override
     public boolean awaitTermination(long timeout, java.util.concurrent.TimeUnit unit) {
-        return true;
+        return isTerminated();
     }
 
     @Override

--- a/http-poja-apache/src/main/java/io/micronaut/http/poja/apache/CurrentThreadExecutorService.java
+++ b/http-poja-apache/src/main/java/io/micronaut/http/poja/apache/CurrentThreadExecutorService.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright 2017-2026 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.http.poja.apache;
+
+import io.micronaut.core.annotation.Internal;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.concurrent.AbstractExecutorService;
+import java.util.concurrent.RejectedExecutionException;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+/**
+ * Executes blocking work immediately on the calling POJA thread.
+ */
+@Internal
+final class CurrentThreadExecutorService extends AbstractExecutorService {
+
+    private final AtomicBoolean shutdown = new AtomicBoolean(false);
+
+    @Override
+    public void shutdown() {
+        shutdown.set(true);
+    }
+
+    @Override
+    public List<Runnable> shutdownNow() {
+        shutdown();
+        return Collections.emptyList();
+    }
+
+    @Override
+    public boolean isShutdown() {
+        return shutdown.get();
+    }
+
+    @Override
+    public boolean isTerminated() {
+        return shutdown.get();
+    }
+
+    @Override
+    public boolean awaitTermination(long timeout, java.util.concurrent.TimeUnit unit) {
+        return true;
+    }
+
+    @Override
+    public void execute(Runnable command) {
+        if (shutdown.get()) {
+            throw new RejectedExecutionException("Executor has been shut down");
+        }
+        command.run();
+    }
+}

--- a/http-poja-apache/src/test/groovy/io/micronaut/http/poja/ApacheBlockingExecutorSpec.groovy
+++ b/http-poja-apache/src/test/groovy/io/micronaut/http/poja/ApacheBlockingExecutorSpec.groovy
@@ -1,0 +1,85 @@
+package io.micronaut.http.poja
+
+import io.micronaut.context.ApplicationContext
+import io.micronaut.http.annotation.Controller
+import io.micronaut.http.annotation.Get
+import io.micronaut.http.poja.apache.ApacheServerlessApplication
+import io.micronaut.scheduling.TaskExecutors
+import io.micronaut.scheduling.annotation.ExecuteOn
+import spock.lang.Specification
+
+import java.nio.charset.StandardCharsets
+
+class ApacheBlockingExecutorSpec extends Specification {
+
+    void "blocking executor runs on calling thread in poja"() {
+        given:
+        Thread thread = Thread.currentThread()
+        String previousName = thread.name
+        String expectedThreadName = "poja-single-thread-test"
+        thread.name = expectedThreadName
+
+        when:
+        String body
+        try (ApplicationContext context = ApplicationContext.run()) {
+            ApacheServerlessApplication application = context.getBean(ApacheServerlessApplication)
+            ByteArrayOutputStream output = new ByteArrayOutputStream()
+            application.start(new ByteArrayInputStream(request("/thread-name")), output)
+            body = responseBody(output)
+        }
+
+        then:
+        body == expectedThreadName
+
+        cleanup:
+        thread.name = previousName
+    }
+
+    void "explicit blocking executor configuration overrides poja default"() {
+        given:
+        Thread thread = Thread.currentThread()
+        String previousName = thread.name
+        String expectedThreadName = "poja-configured-blocking-test"
+        thread.name = expectedThreadName
+
+        when:
+        String body
+        try (ApplicationContext context = ApplicationContext.builder(
+            "micronaut.executors.blocking.type": "fixed",
+            "micronaut.executors.blocking.n-threads": "1"
+        ).start()) {
+            ApacheServerlessApplication application = context.getBean(ApacheServerlessApplication)
+            ByteArrayOutputStream output = new ByteArrayOutputStream()
+            application.start(new ByteArrayInputStream(request("/thread-name")), output)
+            body = responseBody(output)
+        }
+
+        then:
+        body != expectedThreadName
+
+        cleanup:
+        thread.name = previousName
+    }
+
+    private static byte[] request(String path) {
+        ("GET ${path} HTTP/1.1\r\n" +
+            "Connection: close\r\n" +
+            "Host: h\r\n" +
+            "\r\n").getBytes(StandardCharsets.UTF_8)
+    }
+
+    private static String responseBody(ByteArrayOutputStream output) {
+        String response = output.toString(StandardCharsets.UTF_8)
+        response.substring(response.indexOf("\r\n\r\n") + 4)
+    }
+
+    @Controller
+    static final class ThreadNameController {
+
+        @Get("/thread-name")
+        @ExecuteOn(TaskExecutors.BLOCKING)
+        String threadName() {
+            Thread.currentThread().name
+        }
+    }
+}

--- a/http-poja-apache/src/test/groovy/io/micronaut/http/poja/apache/CurrentThreadExecutorServiceSpec.groovy
+++ b/http-poja-apache/src/test/groovy/io/micronaut/http/poja/apache/CurrentThreadExecutorServiceSpec.groovy
@@ -1,0 +1,67 @@
+package io.micronaut.http.poja.apache
+
+import spock.lang.Specification
+
+import java.util.concurrent.RejectedExecutionException
+import java.util.concurrent.TimeUnit
+
+class CurrentThreadExecutorServiceSpec extends Specification {
+
+    void "factory creates current thread executor for blocking tasks"() {
+        when:
+        def executor = new ApacheExecutorServiceFactory().blocking()
+
+        then:
+        executor instanceof CurrentThreadExecutorService
+    }
+
+    void "executor runs commands on the calling thread"() {
+        given:
+        def executor = new CurrentThreadExecutorService()
+        def callingThread = Thread.currentThread()
+        Thread executionThread = null
+
+        when:
+        executor.execute {
+            executionThread = Thread.currentThread()
+        }
+
+        then:
+        executionThread == callingThread
+        !executor.isShutdown()
+        !executor.isTerminated()
+        !executor.awaitTermination(1, TimeUnit.MILLISECONDS)
+    }
+
+    void "shutdown prevents new work and marks executor terminated"() {
+        given:
+        def executor = new CurrentThreadExecutorService()
+
+        when:
+        executor.shutdown()
+
+        then:
+        executor.isShutdown()
+        executor.isTerminated()
+        executor.awaitTermination(1, TimeUnit.MILLISECONDS)
+
+        when:
+        executor.execute { }
+
+        then:
+        thrown(RejectedExecutionException)
+    }
+
+    void "shutdownNow returns no queued work"() {
+        given:
+        def executor = new CurrentThreadExecutorService()
+
+        when:
+        def queued = executor.shutdownNow()
+
+        then:
+        queued.empty
+        executor.isShutdown()
+        executor.isTerminated()
+    }
+}

--- a/http-poja-test/src/main/java/io/micronaut/http/poja/test/TestingServerlessEmbeddedApplication.java
+++ b/http-poja-test/src/main/java/io/micronaut/http/poja/test/TestingServerlessEmbeddedApplication.java
@@ -84,19 +84,34 @@ public class TestingServerlessEmbeddedApplication implements EmbeddedServer {
         createServerSocket();
 
         // Run the thread that sends requests to the server
-        new Thread(() -> {
+        Thread acceptThread = new Thread(() -> {
             while (!serverSocket.isClosed()) {
-                try (Socket socket = serverSocket.accept()) {
-                    application.start(socket.getInputStream(), socket.getOutputStream());
+                try {
+                    Socket socket = serverSocket.accept();
+                    Thread connectionThread = new Thread(() -> handleConnection(socket));
+                    connectionThread.setDaemon(true);
+                    connectionThread.start();
                 } catch (java.net.SocketException ignored) {
                     // Socket closed
                 } catch (IOException e) {
                     throw new UncheckedIOException(e);
                 }
             }
-        }).start();
+        });
+        acceptThread.setDaemon(true);
+        acceptThread.start();
 
         return this;
+    }
+
+    private void handleConnection(Socket socket) {
+        try (socket) {
+            application.start(socket.getInputStream(), socket.getOutputStream());
+        } catch (java.net.SocketException ignored) {
+            // Socket closed
+        } catch (IOException e) {
+            throw new UncheckedIOException(e);
+        }
     }
 
     @Override

--- a/http-poja-test/src/main/java/io/micronaut/http/poja/test/TestingServerlessEmbeddedApplication.java
+++ b/http-poja-test/src/main/java/io/micronaut/http/poja/test/TestingServerlessEmbeddedApplication.java
@@ -33,6 +33,10 @@ import java.net.ServerSocket;
 import java.net.Socket;
 import java.net.URI;
 import java.net.URL;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
 import java.util.concurrent.atomic.AtomicBoolean;
 
 /**
@@ -53,7 +57,9 @@ public class TestingServerlessEmbeddedApplication implements EmbeddedServer {
     private PojaHttpServerlessApplication<?, ?> application;
 
     private final AtomicBoolean isRunning = new AtomicBoolean(false);
+    private final Set<Socket> activeConnections = ConcurrentHashMap.newKeySet();
     private ServerSocket serverSocket;
+    private ExecutorService connectionExecutor;
     private int port;
 
     /**
@@ -82,15 +88,19 @@ public class TestingServerlessEmbeddedApplication implements EmbeddedServer {
             return this; // Already running
         }
         createServerSocket();
+        connectionExecutor = Executors.newCachedThreadPool(runnable -> {
+            Thread thread = new Thread(runnable);
+            thread.setDaemon(true);
+            return thread;
+        });
 
         // Run the thread that sends requests to the server
         Thread acceptThread = new Thread(() -> {
             while (!serverSocket.isClosed()) {
                 try {
                     Socket socket = serverSocket.accept();
-                    Thread connectionThread = new Thread(() -> handleConnection(socket));
-                    connectionThread.setDaemon(true);
-                    connectionThread.start();
+                    activeConnections.add(socket);
+                    connectionExecutor.execute(() -> handleConnection(socket));
                 } catch (java.net.SocketException ignored) {
                     // Socket closed
                 } catch (IOException e) {
@@ -111,12 +121,27 @@ public class TestingServerlessEmbeddedApplication implements EmbeddedServer {
             // Socket closed
         } catch (IOException e) {
             throw new UncheckedIOException(e);
+        } finally {
+            activeConnections.remove(socket);
         }
     }
 
     @Override
     public @NonNull TestingServerlessEmbeddedApplication stop() {
+        isRunning.set(false);
         application.stop();
+        for (Socket connection : activeConnections) {
+            try {
+                connection.close();
+            } catch (IOException e) {
+                throw new UncheckedIOException(e);
+            }
+        }
+        activeConnections.clear();
+        if (connectionExecutor != null) {
+            connectionExecutor.shutdownNow();
+            connectionExecutor = null;
+        }
         try {
             serverSocket.close();
         } catch (IOException e) {

--- a/src/main/docs/guide/httpPoja.adoc
+++ b/src/main/docs/guide/httpPoja.adoc
@@ -1,4 +1,5 @@
 HTTP POJA allows creating Micronaut applications that consume respond to HTTP requests with streams. By default, the application will read requests from standard input stream and write responses to standard output. The requests can only be answered in a serial manner.
+Blocking work also stays on the POJA request thread by default, so using `@ExecuteOn(TaskExecutors.BLOCKING)` does not create additional Micronaut executor threads for POJA applications. If you need different behavior, configure the `blocking` executor explicitly with the standard `micronaut.executors.blocking.*` properties.
 Currently HTTP POJA is based on https://hc.apache.org/httpcomponents-core-5.2.x/[Apache HTTP Core library].
 
 This feature allows creating simple applications that launch and respond on demand with minimal overhead. The module is suitable for usage with `systemd` on Linux or `launchd` on MacOS. Examples are given below.

--- a/src/main/docs/guide/httpPoja.adoc
+++ b/src/main/docs/guide/httpPoja.adoc
@@ -1,4 +1,4 @@
-HTTP POJA allows creating Micronaut applications that consume respond to HTTP requests with streams. By default, the application will read requests from standard input stream and write responses to standard output. The requests can only be answered in a serial manner.
+HTTP POJA allows creating Micronaut applications that consume and respond to HTTP requests with streams. By default, the application will read requests from standard input stream and write responses to standard output. The requests can only be answered in a serial manner.
 Blocking work also stays on the POJA request thread by default, so using `@ExecuteOn(TaskExecutors.BLOCKING)` does not create additional Micronaut executor threads for POJA applications. If you need different behavior, configure the `blocking` executor explicitly with the standard `micronaut.executors.blocking.*` properties.
 Currently HTTP POJA is based on https://hc.apache.org/httpcomponents-core-5.2.x/[Apache HTTP Core library].
 

--- a/test-sample-poja/src/test/java/io/micronaut/http/poja/sample/KeepAliveConnectionTest.java
+++ b/test-sample-poja/src/test/java/io/micronaut/http/poja/sample/KeepAliveConnectionTest.java
@@ -1,0 +1,95 @@
+package io.micronaut.http.poja.sample;
+
+import io.micronaut.runtime.server.EmbeddedServer;
+import io.micronaut.test.extensions.junit5.annotation.MicronautTest;
+import jakarta.inject.Inject;
+import org.junit.jupiter.api.Test;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.net.Socket;
+import java.net.SocketTimeoutException;
+import java.nio.charset.StandardCharsets;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+@MicronautTest
+class KeepAliveConnectionTest {
+
+    private static final int SOCKET_TIMEOUT_MILLIS = 2_000;
+
+    @Inject
+    EmbeddedServer embeddedServer;
+
+    @Test
+    void acceptsSecondConnectionWhileKeepAliveConnectionRemainsOpen() throws IOException {
+        try (Socket keepAliveSocket = socket()) {
+            writeRequest(keepAliveSocket,
+                "GET / HTTP/1.1\r\n" +
+                    "Host: h\r\n" +
+                    "\r\n");
+            assertTrue(readUntilContains(keepAliveSocket.getInputStream(), "Hello, Micronaut Without Netty!\n")
+                .contains("Hello, Micronaut Without Netty!\n"));
+
+            try (Socket secondSocket = socket()) {
+                writeRequest(secondSocket,
+                    "PUT /Andriy HTTP/1.1\r\n" +
+                        "Host: h\r\n" +
+                        "Content-Length: 0\r\n" +
+                        "Connection: close\r\n" +
+                        "\r\n");
+                assertTrue(readUntilContains(secondSocket.getInputStream(), "Hello, Andriy!\n")
+                    .contains("Hello, Andriy!\n"));
+            }
+        }
+    }
+
+    private Socket socket() throws IOException {
+        Socket socket = new Socket(embeddedServer.getHost(), embeddedServer.getPort());
+        socket.setSoTimeout(SOCKET_TIMEOUT_MILLIS);
+        return socket;
+    }
+
+    private static void writeRequest(Socket socket, String request) throws IOException {
+        OutputStream outputStream = socket.getOutputStream();
+        outputStream.write(request.getBytes(StandardCharsets.UTF_8));
+        outputStream.flush();
+    }
+
+    private static String readUntilContains(InputStream inputStream, String expectedBody) throws IOException {
+        byte[] expectedBytes = expectedBody.getBytes(StandardCharsets.UTF_8);
+        ByteArrayOutputStream output = new ByteArrayOutputStream();
+        byte[] buffer = new byte[256];
+        while (true) {
+            int read;
+            try {
+                read = inputStream.read(buffer);
+            } catch (SocketTimeoutException e) {
+                throw new IOException("Timed out waiting for response body: " + expectedBody, e);
+            }
+            if (read < 0) {
+                break;
+            }
+            output.write(buffer, 0, read);
+            if (contains(output.toByteArray(), expectedBytes)) {
+                return output.toString(StandardCharsets.UTF_8);
+            }
+        }
+        return output.toString(StandardCharsets.UTF_8);
+    }
+
+    private static boolean contains(byte[] bytes, byte[] expectedBytes) {
+        outer:
+        for (int i = 0; i <= bytes.length - expectedBytes.length; i++) {
+            for (int j = 0; j < expectedBytes.length; j++) {
+                if (bytes[i + j] != expectedBytes[j]) {
+                    continue outer;
+                }
+            }
+            return true;
+        }
+        return false;
+    }
+}

--- a/test-sample-poja/src/test/java/io/micronaut/http/poja/sample/KeepAliveConnectionTest.java
+++ b/test-sample-poja/src/test/java/io/micronaut/http/poja/sample/KeepAliveConnectionTest.java
@@ -12,8 +12,11 @@ import java.io.OutputStream;
 import java.net.Socket;
 import java.net.SocketTimeoutException;
 import java.nio.charset.StandardCharsets;
+import java.util.Locale;
 
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 @MicronautTest
 class KeepAliveConnectionTest {
@@ -30,8 +33,10 @@ class KeepAliveConnectionTest {
                 "GET / HTTP/1.1\r\n" +
                     "Host: h\r\n" +
                     "\r\n");
-            assertTrue(readUntilContains(keepAliveSocket.getInputStream(), "Hello, Micronaut Without Netty!\n")
-                .contains("Hello, Micronaut Without Netty!\n"));
+            String firstResponse = readUntilContains(keepAliveSocket.getInputStream(), "Hello, Micronaut Without Netty!\n");
+            assertTrue(firstResponse.contains("Hello, Micronaut Without Netty!\n"));
+            assertFalse(firstResponse.toLowerCase(Locale.ROOT).contains("connection: close"));
+            assertConnectionStillOpen(keepAliveSocket);
 
             try (Socket secondSocket = socket()) {
                 writeRequest(secondSocket,
@@ -78,6 +83,18 @@ class KeepAliveConnectionTest {
             }
         }
         return output.toString(StandardCharsets.UTF_8);
+    }
+
+    private static void assertConnectionStillOpen(Socket socket) throws IOException {
+        try {
+            int read = socket.getInputStream().read();
+            if (read < 0) {
+                fail("Expected keep-alive connection to remain open");
+            }
+            fail("Expected keep-alive connection to stay open without immediate extra data");
+        } catch (SocketTimeoutException expected) {
+            // No EOF and no extra data means the connection stayed open.
+        }
     }
 
     private static boolean contains(byte[] bytes, byte[] expectedBytes) {


### PR DESCRIPTION
## Summary
- keep POJA blocking work on the request thread by default
- allow explicit `micronaut.executors.blocking.*` configuration to override the POJA default
- add regression coverage and document the single-thread behavior

## Verification
- `./gradlew -q :micronaut-http-poja-apache:test --tests io.micronaut.http.poja.ApacheBlockingExecutorSpec`
- `./gradlew -q :micronaut-http-poja-apache:test :test-suite-http-server-tck-poja-apache:test`
- `./gradlew -q :micronaut-test-sample-poja:test`
- `./gradlew -q spotlessCheck`

Resolves #800
