### PR TITLE
Fix JDK HTTP server hanging on body-less responses (304, 204, HEAD)

### DIFF
--- a/http-server-jdk/src/main/java/io/micronaut/servlet/http/server/jdk/ServletApiHttpHandler.java
+++ b/http-server-jdk/src/main/java/io/micronaut/servlet/http/server/jdk/ServletApiHttpHandler.java
@@ -28,6 +28,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
+import java.net.HttpURLConnection;
 import java.util.ArrayList;
 
 /**
@@ -74,8 +75,23 @@ final class ServletApiHttpHandler implements HttpHandler {
         for (String headerName : response.getHeaderNames()) {
             exchange.getResponseHeaders().put(headerName, new ArrayList<>(response.getHeaders(headerName)));
         }
-        int contentLength = 0; // If == 0, then chunked encoding is used, and an arbitrary number of bytes may be written.
-        exchange.sendResponseHeaders(response.getStatus(), contentLength);
+        int status = response.getStatus();
+        // A response length of 0 tells the JDK HTTP server to use chunked encoding and expect
+        // an arbitrary number of bytes to be written before close(). That's wrong for statuses
+        // which must never carry a body (1xx, 204, 205, 304) or for HEAD requests, since nothing will
+        // ever be written to the output stream; use -1 (no body) instead so the exchange completes.
+        int contentLength = isBodyAllowed(status, exchange.getRequestMethod()) ? 0 : -1;
+        exchange.sendResponseHeaders(status, contentLength);
+    }
+
+    private static boolean isBodyAllowed(int status, String method) {
+        if ("HEAD".equalsIgnoreCase(method)) {
+            return false;
+        }
+        return status != HttpURLConnection.HTTP_NOT_MODIFIED
+            && status != HttpURLConnection.HTTP_NO_CONTENT
+            && status != HttpURLConnection.HTTP_RESET
+            && status >= HttpURLConnection.HTTP_OK;
     }
 
 }

--- a/http-server-jdk/src/test/java/io/micronaut/servlet/http/server/jdk/StatusTest.java
+++ b/http-server-jdk/src/test/java/io/micronaut/servlet/http/server/jdk/StatusTest.java
@@ -2,6 +2,8 @@ package io.micronaut.servlet.http.server.jdk;
 
 import io.micronaut.context.annotation.Property;
 import io.micronaut.context.annotation.Requires;
+import io.micronaut.http.HttpRequest;
+import io.micronaut.http.HttpResponse;
 import io.micronaut.http.HttpStatus;
 import io.micronaut.http.annotation.Controller;
 import io.micronaut.http.annotation.Get;
@@ -13,6 +15,9 @@ import io.micronaut.security.annotation.Secured;
 import io.micronaut.security.rules.SecurityRule;
 import io.micronaut.test.extensions.junit5.annotation.MicronautTest;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
+
+import java.util.concurrent.TimeUnit;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -28,6 +33,30 @@ class StatusTest {
         assertEquals(HttpStatus.I_AM_A_TEAPOT, ex.getStatus());
     }
 
+    @Test
+    @Timeout(value = 10, unit = TimeUnit.SECONDS)
+    void testNotModifiedStatusDoesNotHangConnection(@Client("/") HttpClient httpClient) {
+        BlockingHttpClient client = httpClient.toBlocking();
+        HttpResponse<?> response = client.exchange("/status/notModified");
+        assertEquals(HttpStatus.NOT_MODIFIED, response.getStatus());
+    }
+
+    @Test
+    @Timeout(value = 10, unit = TimeUnit.SECONDS)
+    void testNoContentStatusDoesNotHangConnection(@Client("/") HttpClient httpClient) {
+        BlockingHttpClient client = httpClient.toBlocking();
+        HttpResponse<?> response = client.exchange("/status/noContent");
+        assertEquals(HttpStatus.NO_CONTENT, response.getStatus());
+    }
+
+    @Test
+    @Timeout(value = 10, unit = TimeUnit.SECONDS)
+    void testHeadRequestDoesNotHangConnection(@Client("/") HttpClient httpClient) {
+        BlockingHttpClient client = httpClient.toBlocking();
+        HttpClientResponseException ex = assertThrows(HttpClientResponseException.class, () -> client.exchange(HttpRequest.HEAD("/status")));
+        assertEquals(HttpStatus.I_AM_A_TEAPOT, ex.getStatus());
+    }
+
     @Secured(SecurityRule.IS_ANONYMOUS)
     @Requires(property = "spec.name", value = "StatusTest")
     @Controller("/status")
@@ -35,6 +64,16 @@ class StatusTest {
         @Get
         HttpStatus index() {
             return HttpStatus.I_AM_A_TEAPOT;
+        }
+
+        @Get("/notModified")
+        HttpResponse<?> notModified() {
+            return HttpResponse.notModified();
+        }
+
+        @Get("/noContent")
+        HttpResponse<?> noContent() {
+            return HttpResponse.noContent();
         }
     }
 }


### PR DESCRIPTION
ServletApiHttpHandler.populateAndSendResponseHeaders always passed a content length of 0 to HttpExchange.sendResponseHeaders, which tells the JDK HTTP server to use chunked encoding and expect an arbitrary number of bytes followed by close(). For statuses that must never carry a body (304 Not Modified, 204 No Content, 1xx) or HEAD requests, no bytes are ever written, leaving the exchange open and the connection hanging indefinitely.

Pass -1 (no body) instead of 0 whenever the response must not contain a body, so the exchange completes immediately.

Fixes #1117