### PR TITLE
Bump Tomcat to 11.0.25 and HttpCore5 to 5.4.3

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -3,10 +3,10 @@ micronaut = "5.1.3"
 managed-servlet-api = '6.1.0'
 kotest-runner = '6.1.11'
 undertow = '2.3.25.Final'
-tomcat = '11.0.23'
+tomcat = '11.0.25'
 bcpkix = "1.70"
 
-managed-apache-http-core5 = "5.4.2"
+managed-apache-http-core5 = "5.4.3"
 managed-jetty = '12.1.10'
 micronaut-reactor = "4.1.0"
 micronaut-security = "5.2.0"


### PR DESCRIPTION
Split out of [#1121](https://github.com/micronaut-projects/micronaut-servlet/pull/1121) at review request: these bumps are unrelated to WebSocket support.

The vulnerability audit reports two actionable findings against the versions currently on `6.2.x`. Both advisories were published while #1121 was open, which is why they first surfaced there.

| Dependency | From | To | Advisories |
|---|---|---|---|
| `org.apache.tomcat.embed:tomcat-embed-core` | 11.0.23 | 11.0.25 | GHSA-9xv2-5v5q-p794, GHSA-gcx9-497g-6cp6, GHSA-h3x4-894j-xpx5 |
| `org.apache.httpcomponents.core5:httpcore5` | 5.4.2 | 5.4.3 | GHSA-hf6x-8p5f-cgmf |

Both are patch bumps within the same minor, to exactly the versions the advisories name as fixed. The change is two lines in `gradle/libs.versions.toml` and nothing else.

`httpcore5` is a managed dependency, so the bump also moves it in the BOM.

## Testing

Verified locally against these versions:

| Suite | Result |
|---|---|
| `http-server-tomcat` | 95 tests |
| HTTP Server TCK for Tomcat | 243 tests |
| `http-poja-apache` / `http-poja-common` | 15 / 6 tests |
| HTTP Server TCK for POJA | 240 tests |

No failures.

## Note on #1121

#1121 currently carries the same two lines, because its `audit` check fails without them. Once this merges I will drop them from that branch. The changes are identical, so they should not conflict in the meantime.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
